### PR TITLE
Change shebang to use env for bash

### DIFF
--- a/apl
+++ b/apl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run APL expression via gritt with ephemeral Dyalog instance
 
 PORT=$((10000 + RANDOM % 50000))


### PR DESCRIPTION
Means one can use their chosen bash runtime instead of the one chosen globally by the OS