### PR TITLE
Make UI accent color configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ gritt looks for `gritt.json` in order:
 
 These are not merged - first found, wins.
 
+The `accent` field sets the UI accent color (borders, highlights, selections). Default is Dyalog orange (`#F2A74F`). For a neutral grey:
+
+```json
+{
+  "accent": "#808080"
+}
+```
+
+Any `#RRGGBB` hex color works. Omit or leave empty for the default.
+
 ## Testing
 
 ```bash

--- a/autocomplete_pane.go
+++ b/autocomplete_pane.go
@@ -57,8 +57,8 @@ func (a *Autocomplete) Render(maxW, maxH int) string {
 		return ""
 	}
 
-	selectedStyle := lipgloss.NewStyle().Background(DyalogOrange).Foreground(lipgloss.Color("0"))
-	borderStyle := lipgloss.NewStyle().Foreground(DyalogOrange)
+	selectedStyle := lipgloss.NewStyle().Background(AccentColor).Foreground(lipgloss.Color("0"))
+	borderStyle := lipgloss.NewStyle().Foreground(AccentColor)
 
 	// Calculate dimensions
 	contentW := 0

--- a/command_palette.go
+++ b/command_palette.go
@@ -64,7 +64,7 @@ func (c *CommandPalette) Render(w, h int) string {
 	var sb strings.Builder
 
 	// Query line
-	promptStyle := lipgloss.NewStyle().Foreground(DyalogOrange)
+	promptStyle := lipgloss.NewStyle().Foreground(AccentColor)
 	sb.WriteString(promptStyle.Render(": "))
 	sb.WriteString(c.query)
 	sb.WriteString(cursorStyle.Render(" "))
@@ -75,7 +75,7 @@ func (c *CommandPalette) Render(w, h int) string {
 	sb.WriteString("\n")
 
 	// Commands list
-	selectedStyle := lipgloss.NewStyle().Background(DyalogOrange).Foreground(lipgloss.Color("0"))
+	selectedStyle := lipgloss.NewStyle().Background(AccentColor).Foreground(lipgloss.Color("0"))
 	helpStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
 
 	listH := h - 2 // Account for query line and separator

--- a/config.go
+++ b/config.go
@@ -14,6 +14,7 @@ var defaultConfigJSON []byte
 
 // Config holds all gritt configuration
 type Config struct {
+	Accent     string           `json:"accent"`
 	Keys       KeyMapConfig     `json:"keys"`
 	TracerKeys TracerKeysConfig `json:"tracer_keys"`
 }

--- a/editor_pane.go
+++ b/editor_pane.go
@@ -52,7 +52,7 @@ func NewEditorPane(w *EditorWindow, tracerKeys TracerKeysConfig, onSave, onClose
 			Foreground(lipgloss.Color("0")),
 		lineNumStyle:    lipgloss.NewStyle().Foreground(lipgloss.Color("243")),
 		breakpointStyle: lipgloss.NewStyle().Foreground(lipgloss.Color("9")), // Red
-		tracerLineStyle: lipgloss.NewStyle().Foreground(DyalogOrange),
+		tracerLineStyle: lipgloss.NewStyle().Foreground(AccentColor),
 		highlightLine:   -1,
 	}
 }

--- a/locals_pane.go
+++ b/locals_pane.go
@@ -42,7 +42,7 @@ func NewVariablesPane(onOpen func(name string), onToggle func(mode VarsMode)) *V
 		onOpen:        onOpen,
 		onToggle:      onToggle,
 		mode:          VarsModeLocals,
-		selectedStyle: lipgloss.NewStyle().Foreground(DyalogOrange),
+		selectedStyle: lipgloss.NewStyle().Foreground(AccentColor),
 		normalStyle:   lipgloss.NewStyle().Foreground(lipgloss.Color("245")),
 	}
 }

--- a/pane.go
+++ b/pane.go
@@ -245,8 +245,8 @@ func (p *Pane) Render() string {
 	}
 
 	// Style borders with Dyalog orange
-	borderStyle := lipgloss.NewStyle().Foreground(DyalogOrange)
-	titleStyle := lipgloss.NewStyle().Foreground(DyalogOrange).Bold(true)
+	borderStyle := lipgloss.NewStyle().Foreground(AccentColor)
+	titleStyle := lipgloss.NewStyle().Foreground(AccentColor).Bold(true)
 
 	contentW := p.Width - 2
 	contentH := p.Height - 2

--- a/stack_pane.go
+++ b/stack_pane.go
@@ -36,7 +36,7 @@ func NewStackPane(getStack func() []StackFrame, onSelect func(token int)) *Stack
 		onSelect:      onSelect,
 		normalStyle:   lipgloss.NewStyle(),
 		selectedStyle: lipgloss.NewStyle().Background(lipgloss.Color("240")),
-		currentStyle:  lipgloss.NewStyle().Foreground(DyalogOrange).Bold(true),
+		currentStyle:  lipgloss.NewStyle().Foreground(AccentColor).Bold(true),
 	}
 }
 


### PR DESCRIPTION
- Add `accent` field to gritt.json config, accepting any `#RRGGBB` hex color
- Default remains Dyalog orange when unset
- Rename `DyalogOrange` to `AccentColor` throughout