### PR TITLE
Replace help_urls.h with symbol-urls.json

### DIFF
--- a/symbol-urls.json
+++ b/symbol-urls.json
@@ -1,0 +1,4618 @@
+[
+  {
+    "symbol": ":if",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/if"
+  },
+  {
+    "symbol": ":else",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/if"
+  },
+  {
+    "symbol": ":orif",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/if"
+  },
+  {
+    "symbol": ":andif",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/if"
+  },
+  {
+    "symbol": ":endif",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/if"
+  },
+  {
+    "symbol": ":elseif",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/control-structures-summary"
+  },
+  {
+    "symbol": ":else",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/control-structures-summary"
+  },
+  {
+    "symbol": ":end",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/control-structures-summary"
+  },
+  {
+    "symbol": ":while",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/while"
+  },
+  {
+    "symbol": ":endwhile",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/while"
+  },
+  {
+    "symbol": ":repeat",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/repeat"
+  },
+  {
+    "symbol": ":until",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/repeat"
+  },
+  {
+    "symbol": ":endrepeat",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/repeat"
+  },
+  {
+    "symbol": ":for",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/for"
+  },
+  {
+    "symbol": ":in",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/for"
+  },
+  {
+    "symbol": ":ineach",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/for"
+  },
+  {
+    "symbol": ":endfor",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/for"
+  },
+  {
+    "symbol": ":select",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/select"
+  },
+  {
+    "symbol": ":case",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/select"
+  },
+  {
+    "symbol": ":caselist",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/select"
+  },
+  {
+    "symbol": ":endselect",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/select"
+  },
+  {
+    "symbol": ":hold",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/hold"
+  },
+  {
+    "symbol": ":endhold",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/hold"
+  },
+  {
+    "symbol": ":with",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/with"
+  },
+  {
+    "symbol": ":endwith",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/with"
+  },
+  {
+    "symbol": ":trap",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/trap"
+  },
+  {
+    "symbol": ":endtrap",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/trap"
+  },
+  {
+    "symbol": ":disposable",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/disposable"
+  },
+  {
+    "symbol": ":enddisposable",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/disposable"
+  },
+  {
+    "symbol": ":goto",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/goto"
+  },
+  {
+    "symbol": ":continue",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/continue"
+  },
+  {
+    "symbol": ":leave",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/leave"
+  },
+  {
+    "symbol": ":return",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/return"
+  },
+  {
+    "symbol": ":access",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/access"
+  },
+  {
+    "symbol": ":implements",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/implements"
+  },
+  {
+    "symbol": ":signature",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/signature"
+  },
+  {
+    "symbol": ":attribute",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/attribute"
+  },
+  {
+    "symbol": ":using",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/using"
+  },
+  {
+    "symbol": ":require",
+    "url": "programming-reference-guide/object-oriented-programming/including-script-files"
+  },
+  {
+    "symbol": ":field",
+    "url": "programming-reference-guide/object-oriented-programming/field-statement"
+  },
+  {
+    "symbol": ":property",
+    "url": "programming-reference-guide/object-oriented-programming/property-section/property-section"
+  },
+  {
+    "symbol": ":endproperty",
+    "url": "programming-reference-guide/object-oriented-programming/property-section/property-section"
+  },
+  {
+    "symbol": ":include",
+    "url": "programming-reference-guide/object-oriented-programming/including-namespaces-in-classes/including-namespaces-in-classes"
+  },
+  {
+    "symbol": ":class",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/class"
+  },
+  {
+    "symbol": ":endclass",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/class"
+  },
+  {
+    "symbol": ":section",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/section"
+  },
+  {
+    "symbol": ":endsection",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/section"
+  },
+  {
+    "symbol": ":namespace",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/namespace"
+  },
+  {
+    "symbol": ":endnamespace",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/namespace"
+  },
+  {
+    "symbol": ":interface",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/interface"
+  },
+  {
+    "symbol": ":endinterface",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/control-structures/interface"
+  },
+  {
+    "symbol": "⌶",
+    "url": "language-reference-guide/primitive-operators/i-beam/index"
+  },
+  {
+    "symbol": "\\'",
+    "url": "language-reference-guide/glyphs"
+  },
+  {
+    "symbol": "⍺",
+    "url": "language-reference-guide/glyphs"
+  },
+  {
+    "symbol": "⍵",
+    "url": "language-reference-guide/glyphs"
+  },
+  {
+    "symbol": "_",
+    "url": "language-reference-guide/glyphs"
+  },
+  {
+    "symbol": "¯",
+    "url": "language-reference-guide/glyphs"
+  },
+  {
+    "symbol": ".",
+    "url": "language-reference-guide/symbols/dot"
+  },
+  {
+    "symbol": "⍬",
+    "url": "language-reference-guide/symbols/zilde"
+  },
+  {
+    "symbol": "⊢",
+    "url": "language-reference-guide/symbols/right-tack"
+  },
+  {
+    "symbol": "∆",
+    "url": "language-reference-guide/glyphs"
+  },
+  {
+    "symbol": "⍙",
+    "url": "language-reference-guide/glyphs"
+  },
+  {
+    "symbol": "{",
+    "url": "language-reference-guide/glyphs"
+  },
+  {
+    "symbol": "}",
+    "url": "language-reference-guide/glyphs"
+  },
+  {
+    "symbol": "⊣",
+    "url": "language-reference-guide/symbols/left-tack"
+  },
+  {
+    "symbol": "⌷",
+    "url": "language-reference-guide/symbols/squad"
+  },
+  {
+    "symbol": "¨",
+    "url": "language-reference-guide/symbols/diaeresis"
+  },
+  {
+    "symbol": "⍨",
+    "url": "language-reference-guide/symbols/tilde-diaeresis"
+  },
+  {
+    "symbol": "[",
+    "url": "language-reference-guide/glyphs"
+  },
+  {
+    "symbol": "/",
+    "url": "language-reference-guide/symbols/slash"
+  },
+  {
+    "symbol": "⌿",
+    "url": "language-reference-guide/symbols/slash-bar"
+  },
+  {
+    "symbol": "\\\\",
+    "url": "language-reference-guide/symbols/backslash"
+  },
+  {
+    "symbol": "⍀",
+    "url": "language-reference-guide/symbols/backslash-bar"
+  },
+  {
+    "symbol": "\u003c",
+    "url": "language-reference-guide/symbols/less-than"
+  },
+  {
+    "symbol": "≤",
+    "url": "language-reference-guide/symbols/less-than-or-equal-to"
+  },
+  {
+    "symbol": "=",
+    "url": "language-reference-guide/symbols/equal"
+  },
+  {
+    "symbol": "≥",
+    "url": "language-reference-guide/symbols/greater-than-or-equal-to"
+  },
+  {
+    "symbol": "\u003e",
+    "url": "language-reference-guide/symbols/greater-than"
+  },
+  {
+    "symbol": "≠",
+    "url": "language-reference-guide/symbols/not-equal"
+  },
+  {
+    "symbol": "∨",
+    "url": "language-reference-guide/symbols/logical-or"
+  },
+  {
+    "symbol": "∧",
+    "url": "language-reference-guide/symbols/logical-and"
+  },
+  {
+    "symbol": "-",
+    "url": "language-reference-guide/symbols/minus"
+  },
+  {
+    "symbol": "+",
+    "url": "language-reference-guide/symbols/plus"
+  },
+  {
+    "symbol": "÷",
+    "url": "language-reference-guide/symbols/divide"
+  },
+  {
+    "symbol": "×",
+    "url": "language-reference-guide/symbols/times"
+  },
+  {
+    "symbol": "?",
+    "url": "language-reference-guide/symbols/question-mark"
+  },
+  {
+    "symbol": "∊",
+    "url": "language-reference-guide/symbols/epsilon"
+  },
+  {
+    "symbol": "⍴",
+    "url": "language-reference-guide/symbols/rho"
+  },
+  {
+    "symbol": "~",
+    "url": "language-reference-guide/symbols/tilde"
+  },
+  {
+    "symbol": "↑",
+    "url": "language-reference-guide/symbols/up-arrow"
+  },
+  {
+    "symbol": "↓",
+    "url": "language-reference-guide/symbols/down-arrow"
+  },
+  {
+    "symbol": "⍳",
+    "url": "language-reference-guide/symbols/iota"
+  },
+  {
+    "symbol": "○",
+    "url": "language-reference-guide/symbols/circle"
+  },
+  {
+    "symbol": "*",
+    "url": "language-reference-guide/symbols/star"
+  },
+  {
+    "symbol": "⌈",
+    "url": "language-reference-guide/symbols/upstile"
+  },
+  {
+    "symbol": "⌊",
+    "url": "language-reference-guide/symbols/downstile"
+  },
+  {
+    "symbol": "∇",
+    "url": "language-reference-guide/glyphs"
+  },
+  {
+    "symbol": "∘",
+    "url": "language-reference-guide/symbols/jot"
+  },
+  {
+    "symbol": "⍛",
+    "url": "language-reference-guide/symbols/jot-underbar"
+  },
+  {
+    "symbol": "(",
+    "url": "language-reference-guide/glyphs"
+  },
+  {
+    "symbol": "⊂",
+    "url": "language-reference-guide/symbols/left-shoe"
+  },
+  {
+    "symbol": "⊃",
+    "url": "language-reference-guide/symbols/right-shoe"
+  },
+  {
+    "symbol": "∩",
+    "url": "language-reference-guide/symbols/up-shoe"
+  },
+  {
+    "symbol": "∪",
+    "url": "language-reference-guide/symbols/down-shoe"
+  },
+  {
+    "symbol": "⊥",
+    "url": "language-reference-guide/symbols/up-tack"
+  },
+  {
+    "symbol": "⊤",
+    "url": "language-reference-guide/symbols/down-tack"
+  },
+  {
+    "symbol": "|",
+    "url": "language-reference-guide/symbols/stile"
+  },
+  {
+    "symbol": ";",
+    "url": "language-reference-guide/glyphs"
+  },
+  {
+    "symbol": ",",
+    "url": "language-reference-guide/symbols/comma"
+  },
+  {
+    "symbol": "⍱",
+    "url": "language-reference-guide/symbols/logical-nor"
+  },
+  {
+    "symbol": "⍲",
+    "url": "language-reference-guide/symbols/logical-nand"
+  },
+  {
+    "symbol": "⍒",
+    "url": "language-reference-guide/symbols/grade-down"
+  },
+  {
+    "symbol": "⍋",
+    "url": "language-reference-guide/symbols/grade-up"
+  },
+  {
+    "symbol": "⍉",
+    "url": "language-reference-guide/symbols/circle-backslash"
+  },
+  {
+    "symbol": "⌽",
+    "url": "language-reference-guide/symbols/circle-stile"
+  },
+  {
+    "symbol": "⊖",
+    "url": "language-reference-guide/symbols/circle-bar"
+  },
+  {
+    "symbol": "⍟",
+    "url": "language-reference-guide/symbols/log"
+  },
+  {
+    "symbol": "⌹",
+    "url": "language-reference-guide/symbols/domino"
+  },
+  {
+    "symbol": "!",
+    "url": "language-reference-guide/symbols/exclamation-mark"
+  },
+  {
+    "symbol": "⍕",
+    "url": "language-reference-guide/symbols/thorn"
+  },
+  {
+    "symbol": "⍎",
+    "url": "language-reference-guide/symbols/hydrant"
+  },
+  {
+    "symbol": "⍫",
+    "url": "language-reference-guide/glyphs"
+  },
+  {
+    "symbol": "⍪",
+    "url": "language-reference-guide/symbols/comma-bar"
+  },
+  {
+    "symbol": "≡",
+    "url": "language-reference-guide/symbols/equal-underbar"
+  },
+  {
+    "symbol": "≢",
+    "url": "language-reference-guide/symbols/equal-underbar-slash"
+  },
+  {
+    "symbol": "#",
+    "url": "language-reference-guide/glyphs"
+  },
+  {
+    "symbol": "\u0026",
+    "url": "language-reference-guide/symbols/ampersand"
+  },
+  {
+    "symbol": "@",
+    "url": "language-reference-guide/symbols/at"
+  },
+  {
+    "symbol": ":",
+    "url": "language-reference-guide/glyphs"
+  },
+  {
+    "symbol": "⍷",
+    "url": "language-reference-guide/symbols/epsilon-underbar"
+  },
+  {
+    "symbol": "⋄",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/statements"
+  },
+  {
+    "symbol": "←",
+    "url": "language-reference-guide/symbols/left-arrow"
+  },
+  {
+    "symbol": "→",
+    "url": "language-reference-guide/symbols/right-arrow"
+  },
+  {
+    "symbol": "⍝",
+    "url": "programming-reference-guide/defined-functions-and-operators/traditional-functions-and-operators/statements"
+  },
+  {
+    "symbol": ")",
+    "url": "language-reference-guide/glyphs"
+  },
+  {
+    "symbol": "]",
+    "url": "language-reference-guide/glyphs"
+  },
+  {
+    "symbol": "⍣",
+    "url": "language-reference-guide/symbols/star-diaeresis"
+  },
+  {
+    "symbol": "⊆",
+    "url": "language-reference-guide/symbols/left-shoe-underbar"
+  },
+  {
+    "symbol": "⎕U2286",
+    "url": "language-reference-guide/symbols/left-shoe-underbar"
+  },
+  {
+    "symbol": "⌸",
+    "url": "language-reference-guide/symbols/quad-equal"
+  },
+  {
+    "symbol": "⎕U2338",
+    "url": "language-reference-guide/symbols/quad-equal"
+  },
+  {
+    "symbol": "⌺",
+    "url": "language-reference-guide/symbols/quad-diamond"
+  },
+  {
+    "symbol": "⎕U233A",
+    "url": "language-reference-guide/symbols/quad-diamond"
+  },
+  {
+    "symbol": "⍛",
+    "url": "language-reference-guide/symbols/jot-underbar"
+  },
+  {
+    "symbol": "⎕U235B",
+    "url": "language-reference-guide/symbols/jot-underbar"
+  },
+  {
+    "symbol": "⍠",
+    "url": "language-reference-guide/symbols/quad-colon"
+  },
+  {
+    "symbol": "⎕OPT",
+    "url": "language-reference-guide/symbols/quad-colon"
+  },
+  {
+    "symbol": "⎕U2360",
+    "url": "language-reference-guide/symbols/quad-colon"
+  },
+  {
+    "symbol": "⍤",
+    "url": "language-reference-guide/symbols/jot-diaeresis"
+  },
+  {
+    "symbol": "⎕U2364",
+    "url": "language-reference-guide/symbols/jot-diaeresis"
+  },
+  {
+    "symbol": "⍥",
+    "url": "language-reference-guide/symbols/circle-diaeresis"
+  },
+  {
+    "symbol": "⎕U2365",
+    "url": "language-reference-guide/symbols/circle-diaeresis"
+  },
+  {
+    "symbol": "⍸",
+    "url": "language-reference-guide/symbols/iota-underbar"
+  },
+  {
+    "symbol": "⎕U2378",
+    "url": "language-reference-guide/symbols/iota-underbar"
+  },
+  {
+    "symbol": ")CLEAR",
+    "url": "language-reference-guide/system-commands/clear"
+  },
+  {
+    "symbol": ")CMD",
+    "url": "language-reference-guide/system-commands/cmd"
+  },
+  {
+    "symbol": ")CONTINUE",
+    "url": "language-reference-guide/system-commands/continue"
+  },
+  {
+    "symbol": ")COPY",
+    "url": "language-reference-guide/system-commands/copy"
+  },
+  {
+    "symbol": ")CS",
+    "url": "language-reference-guide/system-commands/cs"
+  },
+  {
+    "symbol": ")DROP",
+    "url": "language-reference-guide/system-commands/drop"
+  },
+  {
+    "symbol": ")ED",
+    "url": "language-reference-guide/system-commands/ed"
+  },
+  {
+    "symbol": ")ERASE",
+    "url": "language-reference-guide/system-commands/erase"
+  },
+  {
+    "symbol": ")EVENTS",
+    "url": "language-reference-guide/system-commands/events"
+  },
+  {
+    "symbol": ")FNS",
+    "url": "language-reference-guide/system-commands/fns"
+  },
+  {
+    "symbol": ")LIB",
+    "url": "language-reference-guide/system-commands/lib"
+  },
+  {
+    "symbol": ")LOAD",
+    "url": "language-reference-guide/system-commands/load"
+  },
+  {
+    "symbol": ")METHODS",
+    "url": "language-reference-guide/system-commands/methods"
+  },
+  {
+    "symbol": ")NS",
+    "url": "language-reference-guide/system-commands/ns"
+  },
+  {
+    "symbol": ")OBS",
+    "url": "language-reference-guide/system-commands/obs"
+  },
+  {
+    "symbol": ")OBJECTS",
+    "url": "language-reference-guide/system-commands/objects"
+  },
+  {
+    "symbol": ")OFF",
+    "url": "language-reference-guide/system-commands/off"
+  },
+  {
+    "symbol": ")OPS",
+    "url": "language-reference-guide/system-commands/ops"
+  },
+  {
+    "symbol": ")PCOPY",
+    "url": "language-reference-guide/system-commands/pcopy"
+  },
+  {
+    "symbol": ")PROPS",
+    "url": "language-reference-guide/system-commands/props"
+  },
+  {
+    "symbol": ")RESET",
+    "url": "language-reference-guide/system-commands/reset"
+  },
+  {
+    "symbol": ")SAVE",
+    "url": "language-reference-guide/system-commands/save"
+  },
+  {
+    "symbol": ")SH",
+    "url": "language-reference-guide/system-commands/sh"
+  },
+  {
+    "symbol": ")SI",
+    "url": "language-reference-guide/system-commands/si"
+  },
+  {
+    "symbol": ")SINL",
+    "url": "language-reference-guide/system-commands/sinl"
+  },
+  {
+    "symbol": ")HOLDS",
+    "url": "language-reference-guide/system-commands/holds"
+  },
+  {
+    "symbol": ")TID",
+    "url": "language-reference-guide/system-commands/tid"
+  },
+  {
+    "symbol": ")VARS",
+    "url": "language-reference-guide/system-commands/vars"
+  },
+  {
+    "symbol": ")WSID",
+    "url": "language-reference-guide/system-commands/wsid"
+  },
+  {
+    "symbol": ")XLOAD",
+    "url": "language-reference-guide/system-commands/xload"
+  },
+  {
+    "symbol": ")CLASSES",
+    "url": "language-reference-guide/system-commands/classes"
+  },
+  {
+    "symbol": ")SIC",
+    "url": "language-reference-guide/system-commands/sic"
+  },
+  {
+    "symbol": "⎕",
+    "url": "language-reference-guide/system-functions/evaluated-input-output"
+  },
+  {
+    "symbol": "⍞",
+    "url": "language-reference-guide/system-functions/character-input-output"
+  },
+  {
+    "symbol": "⎕A",
+    "url": "language-reference-guide/system-functions/a"
+  },
+  {
+    "symbol": "⎕AI",
+    "url": "language-reference-guide/system-functions/ai"
+  },
+  {
+    "symbol": "⎕AN",
+    "url": "language-reference-guide/system-functions/an"
+  },
+  {
+    "symbol": "⎕AV",
+    "url": "language-reference-guide/system-functions/av"
+  },
+  {
+    "symbol": "⎕CLEAR",
+    "url": "language-reference-guide/system-functions/clear"
+  },
+  {
+    "symbol": "⎕D",
+    "url": "language-reference-guide/system-functions/d"
+  },
+  {
+    "symbol": "⎕DM",
+    "url": "language-reference-guide/system-functions/dm"
+  },
+  {
+    "symbol": "⎕EN",
+    "url": "language-reference-guide/system-functions/en"
+  },
+  {
+    "symbol": "⎕EXCEPTION",
+    "url": "language-reference-guide/system-functions/exception"
+  },
+  {
+    "symbol": "⎕FAVAIL",
+    "url": "language-reference-guide/system-functions/favail"
+  },
+  {
+    "symbol": "⎕FNAMES",
+    "url": "language-reference-guide/system-functions/fnames"
+  },
+  {
+    "symbol": "⎕FNUMS",
+    "url": "language-reference-guide/system-functions/fnums"
+  },
+  {
+    "symbol": "⎕LC",
+    "url": "language-reference-guide/system-functions/lc"
+  },
+  {
+    "symbol": "⎕NNAMES",
+    "url": "language-reference-guide/system-functions/nnames"
+  },
+  {
+    "symbol": "⎕NNUMS",
+    "url": "language-reference-guide/system-functions/nnums"
+  },
+  {
+    "symbol": "⎕NSI",
+    "url": "language-reference-guide/system-functions/nsi"
+  },
+  {
+    "symbol": "⎕NULL",
+    "url": "language-reference-guide/system-functions/null"
+  },
+  {
+    "symbol": "⎕OFF",
+    "url": "language-reference-guide/system-functions/off"
+  },
+  {
+    "symbol": "⎕RSI",
+    "url": "language-reference-guide/system-functions/rsi"
+  },
+  {
+    "symbol": "⎕SD",
+    "url": "language-reference-guide/system-functions/sd"
+  },
+  {
+    "symbol": "⎕SI",
+    "url": "language-reference-guide/system-functions/si"
+  },
+  {
+    "symbol": "⎕STACK",
+    "url": "language-reference-guide/system-functions/stack"
+  },
+  {
+    "symbol": "⎕TC",
+    "url": "language-reference-guide/system-functions/tc"
+  },
+  {
+    "symbol": "⎕TID",
+    "url": "language-reference-guide/system-functions/tid"
+  },
+  {
+    "symbol": "⎕TNUMS",
+    "url": "language-reference-guide/system-functions/tnums"
+  },
+  {
+    "symbol": "⎕TPOOL",
+    "url": "language-reference-guide/system-functions/tpool"
+  },
+  {
+    "symbol": "⎕TS",
+    "url": "language-reference-guide/system-functions/ts"
+  },
+  {
+    "symbol": "⎕WA",
+    "url": "language-reference-guide/system-functions/wa"
+  },
+  {
+    "symbol": "⎕XSI",
+    "url": "language-reference-guide/system-functions/xsi"
+  },
+  {
+    "symbol": "⎕Á",
+    "url": "language-reference-guide/system-functions/underscored-alphabetic-characters"
+  },
+  {
+    "symbol": "⎕THIS",
+    "url": "language-reference-guide/system-functions/this"
+  },
+  {
+    "symbol": "⎕BASE",
+    "url": "language-reference-guide/system-functions/base"
+  },
+  {
+    "symbol": "⎕ARBIN",
+    "url": "language-reference-guide/system-functions/arbin"
+  },
+  {
+    "symbol": "⎕ARBOUT",
+    "url": "language-reference-guide/system-functions/arbout"
+  },
+  {
+    "symbol": "⎕AT",
+    "url": "language-reference-guide/system-functions/at"
+  },
+  {
+    "symbol": "⎕ATX",
+    "url": "language-reference-guide/system-functions/atx"
+  },
+  {
+    "symbol": "⎕CLASS",
+    "url": "language-reference-guide/system-functions/class"
+  },
+  {
+    "symbol": "⎕CMD",
+    "url": "language-reference-guide/system-functions/cmd"
+  },
+  {
+    "symbol": "⎕CR",
+    "url": "language-reference-guide/system-functions/cr"
+  },
+  {
+    "symbol": "⎕CS",
+    "url": "language-reference-guide/system-functions/cs"
+  },
+  {
+    "symbol": "⎕CSV",
+    "url": "language-reference-guide/system-functions/csv"
+  },
+  {
+    "symbol": "⎕CY",
+    "url": "language-reference-guide/system-functions/cy"
+  },
+  {
+    "symbol": "⎕DF",
+    "url": "language-reference-guide/system-functions/df"
+  },
+  {
+    "symbol": "⎕DL",
+    "url": "language-reference-guide/system-functions/dl"
+  },
+  {
+    "symbol": "⎕DQ",
+    "url": "language-reference-guide/system-functions/dq"
+  },
+  {
+    "symbol": "⎕DR",
+    "url": "language-reference-guide/system-functions/dr"
+  },
+  {
+    "symbol": "⎕ED",
+    "url": "language-reference-guide/system-functions/ed"
+  },
+  {
+    "symbol": "⎕EM",
+    "url": "language-reference-guide/system-functions/em"
+  },
+  {
+    "symbol": "⎕EX",
+    "url": "language-reference-guide/system-functions/ex"
+  },
+  {
+    "symbol": "⎕EXPORT",
+    "url": "language-reference-guide/system-functions/export"
+  },
+  {
+    "symbol": "⎕FAPPEND",
+    "url": "language-reference-guide/system-functions/fappend"
+  },
+  {
+    "symbol": "⎕FCHK",
+    "url": "language-reference-guide/system-functions/fchk"
+  },
+  {
+    "symbol": "⎕FCOPY",
+    "url": "language-reference-guide/system-functions/fcopy"
+  },
+  {
+    "symbol": "⎕FCREATE",
+    "url": "language-reference-guide/system-functions/fcreate"
+  },
+  {
+    "symbol": "⎕FDROP",
+    "url": "language-reference-guide/system-functions/fdrop"
+  },
+  {
+    "symbol": "⎕FERASE",
+    "url": "language-reference-guide/system-functions/ferase"
+  },
+  {
+    "symbol": "⎕FHOLD",
+    "url": "language-reference-guide/system-functions/fhold"
+  },
+  {
+    "symbol": "⎕FIX",
+    "url": "language-reference-guide/system-functions/fix"
+  },
+  {
+    "symbol": "⎕FLIB",
+    "url": "language-reference-guide/system-functions/flib"
+  },
+  {
+    "symbol": "⎕FMT",
+    "url": "language-reference-guide/system-functions/fmt"
+  },
+  {
+    "symbol": "⎕FPROPS",
+    "url": "language-reference-guide/system-functions/fprops"
+  },
+  {
+    "symbol": "⎕FRDAC",
+    "url": "language-reference-guide/system-functions/frdac"
+  },
+  {
+    "symbol": "⎕FRDCI",
+    "url": "language-reference-guide/system-functions/frdci"
+  },
+  {
+    "symbol": "⎕FREAD",
+    "url": "language-reference-guide/system-functions/fread"
+  },
+  {
+    "symbol": "⎕FRENAME",
+    "url": "language-reference-guide/system-functions/frename"
+  },
+  {
+    "symbol": "⎕FREPLACE",
+    "url": "language-reference-guide/system-functions/freplace"
+  },
+  {
+    "symbol": "⎕FRESIZE",
+    "url": "language-reference-guide/system-functions/fresize"
+  },
+  {
+    "symbol": "⎕FSIZE",
+    "url": "language-reference-guide/system-functions/fsize"
+  },
+  {
+    "symbol": "⎕FSTAC",
+    "url": "language-reference-guide/system-functions/fstac"
+  },
+  {
+    "symbol": "⎕FSTIE",
+    "url": "language-reference-guide/system-functions/fstie"
+  },
+  {
+    "symbol": "⎕FTIE",
+    "url": "language-reference-guide/system-functions/ftie"
+  },
+  {
+    "symbol": "⎕FUNTIE",
+    "url": "language-reference-guide/system-functions/funtie"
+  },
+  {
+    "symbol": "⎕FX",
+    "url": "language-reference-guide/system-functions/fx"
+  },
+  {
+    "symbol": "⎕INSTANCES",
+    "url": "language-reference-guide/system-functions/instances"
+  },
+  {
+    "symbol": "⎕JSON",
+    "url": "language-reference-guide/system-functions/json"
+  },
+  {
+    "symbol": "⎕KL",
+    "url": "language-reference-guide/system-functions/kl"
+  },
+  {
+    "symbol": "⎕LOAD",
+    "url": "language-reference-guide/system-functions/load"
+  },
+  {
+    "symbol": "⎕LOCK",
+    "url": "language-reference-guide/system-functions/lock"
+  },
+  {
+    "symbol": "⎕MKDIR",
+    "url": "language-reference-guide/system-functions/mkdir"
+  },
+  {
+    "symbol": "⎕MONITOR",
+    "url": "language-reference-guide/system-functions/monitor"
+  },
+  {
+    "symbol": "⎕NA",
+    "url": "language-reference-guide/system-functions/na"
+  },
+  {
+    "symbol": "⎕NAPPEND",
+    "url": "language-reference-guide/system-functions/nappend"
+  },
+  {
+    "symbol": "⎕NC",
+    "url": "language-reference-guide/system-functions/nc"
+  },
+  {
+    "symbol": "⎕NCOPY",
+    "url": "language-reference-guide/system-functions/ncopy"
+  },
+  {
+    "symbol": "⎕NCREATE",
+    "url": "language-reference-guide/system-functions/ncreate"
+  },
+  {
+    "symbol": "⎕NDELETE",
+    "url": "language-reference-guide/system-functions/ndelete"
+  },
+  {
+    "symbol": "⎕NERASE",
+    "url": "language-reference-guide/system-functions/nerase"
+  },
+  {
+    "symbol": "⎕NEXISTS",
+    "url": "language-reference-guide/system-functions/nexists"
+  },
+  {
+    "symbol": "⎕NGET",
+    "url": "language-reference-guide/system-functions/nget"
+  },
+  {
+    "symbol": "⎕NINFO",
+    "url": "language-reference-guide/system-functions/ninfo"
+  },
+  {
+    "symbol": "⎕NL",
+    "url": "language-reference-guide/system-functions/nl"
+  },
+  {
+    "symbol": "⎕NLOCK",
+    "url": "language-reference-guide/system-functions/nlock"
+  },
+  {
+    "symbol": "⎕NMOVE",
+    "url": "language-reference-guide/system-functions/nmove"
+  },
+  {
+    "symbol": "⎕NPARTS",
+    "url": "language-reference-guide/system-functions/nparts"
+  },
+  {
+    "symbol": "⎕NPUT",
+    "url": "language-reference-guide/system-functions/nput"
+  },
+  {
+    "symbol": "⎕NQ",
+    "url": "language-reference-guide/system-functions/nq"
+  },
+  {
+    "symbol": "⎕NR",
+    "url": "language-reference-guide/system-functions/nr"
+  },
+  {
+    "symbol": "⎕NREAD",
+    "url": "language-reference-guide/system-functions/nread"
+  },
+  {
+    "symbol": "⎕NRENAME",
+    "url": "language-reference-guide/system-functions/nrename"
+  },
+  {
+    "symbol": "⎕NREPLACE",
+    "url": "language-reference-guide/system-functions/nreplace"
+  },
+  {
+    "symbol": "⎕NRESIZE",
+    "url": "language-reference-guide/system-functions/nresize"
+  },
+  {
+    "symbol": "⎕NS",
+    "url": "language-reference-guide/system-functions/ns"
+  },
+  {
+    "symbol": "⎕NSIZE",
+    "url": "language-reference-guide/system-functions/nsize"
+  },
+  {
+    "symbol": "⎕NTIE",
+    "url": "language-reference-guide/system-functions/ntie"
+  },
+  {
+    "symbol": "⎕NUNTIE",
+    "url": "language-reference-guide/system-functions/nuntie"
+  },
+  {
+    "symbol": "⎕NXLATE",
+    "url": "language-reference-guide/system-functions/nxlate"
+  },
+  {
+    "symbol": "⎕MAP",
+    "url": "language-reference-guide/system-functions/map"
+  },
+  {
+    "symbol": "⎕NEW",
+    "url": "language-reference-guide/system-functions/new"
+  },
+  {
+    "symbol": "⎕OR",
+    "url": "language-reference-guide/system-functions/or"
+  },
+  {
+    "symbol": "⎕PFKEY",
+    "url": "language-reference-guide/system-functions/pfkey"
+  },
+  {
+    "symbol": "⎕PROFILE",
+    "url": "language-reference-guide/system-functions/profile"
+  },
+  {
+    "symbol": "⎕FHIST",
+    "url": "language-reference-guide/system-functions/fhist"
+  },
+  {
+    "symbol": "⎕REFS",
+    "url": "language-reference-guide/system-functions/refs"
+  },
+  {
+    "symbol": "⎕SAVE",
+    "url": "language-reference-guide/system-functions/save"
+  },
+  {
+    "symbol": "⎕SH",
+    "url": "language-reference-guide/system-functions/sh"
+  },
+  {
+    "symbol": "⎕SHELL",
+    "url": "language-reference-guide/system-functions/shell"
+  },
+  {
+    "symbol": "⎕SHADOW",
+    "url": "language-reference-guide/system-functions/shadow"
+  },
+  {
+    "symbol": "⎕SHELL",
+    "url": "language-reference-guide/system-functions/shell"
+  },
+  {
+    "symbol": "⎕SIGNAL",
+    "url": "language-reference-guide/system-functions/signal"
+  },
+  {
+    "symbol": "⎕SIZE",
+    "url": "language-reference-guide/system-functions/size"
+  },
+  {
+    "symbol": "⎕SR",
+    "url": "language-reference-guide/system-functions/sr"
+  },
+  {
+    "symbol": "⎕SRC",
+    "url": "language-reference-guide/system-functions/src"
+  },
+  {
+    "symbol": "⎕STATE",
+    "url": "language-reference-guide/system-functions/state"
+  },
+  {
+    "symbol": "⎕STOP",
+    "url": "language-reference-guide/system-functions/stop"
+  },
+  {
+    "symbol": "⎕SVC",
+    "url": "language-reference-guide/system-functions/svc"
+  },
+  {
+    "symbol": "⎕SVO",
+    "url": "language-reference-guide/system-functions/svo"
+  },
+  {
+    "symbol": "⎕SVQ",
+    "url": "language-reference-guide/system-functions/svq"
+  },
+  {
+    "symbol": "⎕SVR",
+    "url": "language-reference-guide/system-functions/svr"
+  },
+  {
+    "symbol": "⎕SVS",
+    "url": "language-reference-guide/system-functions/svs"
+  },
+  {
+    "symbol": "⎕TALLOC",
+    "url": "language-reference-guide/system-functions/talloc"
+  },
+  {
+    "symbol": "⎕TKILL",
+    "url": "language-reference-guide/system-functions/tkill"
+  },
+  {
+    "symbol": "⎕TCNUMS",
+    "url": "language-reference-guide/system-functions/tcnums"
+  },
+  {
+    "symbol": "⎕TSYNC",
+    "url": "language-reference-guide/system-functions/tsync"
+  },
+  {
+    "symbol": "⎕TRACE",
+    "url": "language-reference-guide/system-functions/trace"
+  },
+  {
+    "symbol": "⎕TGET",
+    "url": "language-reference-guide/system-functions/tget"
+  },
+  {
+    "symbol": "⎕TPUT",
+    "url": "language-reference-guide/system-functions/tput"
+  },
+  {
+    "symbol": "⎕TREQ",
+    "url": "language-reference-guide/system-functions/treq"
+  },
+  {
+    "symbol": "⎕UCS",
+    "url": "language-reference-guide/system-functions/ucs"
+  },
+  {
+    "symbol": "⎕VFI",
+    "url": "language-reference-guide/system-functions/vfi"
+  },
+  {
+    "symbol": "⎕VGET",
+    "url": "language-reference-guide/system-functions/vget"
+  },
+  {
+    "symbol": "⎕VR",
+    "url": "language-reference-guide/system-functions/vr"
+  },
+  {
+    "symbol": "⎕VSET",
+    "url": "language-reference-guide/system-functions/vset"
+  },
+  {
+    "symbol": "⎕WC",
+    "url": "language-reference-guide/system-functions/wc"
+  },
+  {
+    "symbol": "⎕WG",
+    "url": "language-reference-guide/system-functions/wg"
+  },
+  {
+    "symbol": "⎕WN",
+    "url": "language-reference-guide/system-functions/wn"
+  },
+  {
+    "symbol": "⎕WS",
+    "url": "language-reference-guide/system-functions/ws"
+  },
+  {
+    "symbol": "⎕XML",
+    "url": "language-reference-guide/system-functions/xml"
+  },
+  {
+    "symbol": "⎕XT",
+    "url": "language-reference-guide/system-functions/xt"
+  },
+  {
+    "symbol": "⎕DT",
+    "url": "language-reference-guide/system-functions/dt"
+  },
+  {
+    "symbol": "⎕C",
+    "url": "language-reference-guide/system-functions/c"
+  },
+  {
+    "symbol": "⎕R",
+    "url": "language-reference-guide/system-functions/r"
+  },
+  {
+    "symbol": "⎕S",
+    "url": "language-reference-guide/system-functions/s"
+  },
+  {
+    "symbol": "⎕PW",
+    "url": "language-reference-guide/system-functions/pw"
+  },
+  {
+    "symbol": "⎕SE",
+    "url": "language-reference-guide/system-functions/se"
+  },
+  {
+    "symbol": "⎕PATH",
+    "url": "language-reference-guide/system-functions/path"
+  },
+  {
+    "symbol": "⎕LX",
+    "url": "language-reference-guide/system-functions/lx"
+  },
+  {
+    "symbol": "⎕SM",
+    "url": "language-reference-guide/system-functions/sm"
+  },
+  {
+    "symbol": "⎕TRAP",
+    "url": "language-reference-guide/system-functions/trap"
+  },
+  {
+    "symbol": "⎕WSID",
+    "url": "language-reference-guide/system-functions/wsid"
+  },
+  {
+    "symbol": "⎕TNAME",
+    "url": "language-reference-guide/system-functions/tname"
+  },
+  {
+    "symbol": "⎕DMX",
+    "url": "language-reference-guide/system-functions/dmx"
+  },
+  {
+    "symbol": "⎕CT",
+    "url": "language-reference-guide/system-functions/ct"
+  },
+  {
+    "symbol": "⎕DIV",
+    "url": "language-reference-guide/system-functions/div"
+  },
+  {
+    "symbol": "⎕IO",
+    "url": "language-reference-guide/system-functions/io"
+  },
+  {
+    "symbol": "⎕ML",
+    "url": "language-reference-guide/system-functions/ml"
+  },
+  {
+    "symbol": "⎕PP",
+    "url": "language-reference-guide/system-functions/pp"
+  },
+  {
+    "symbol": "⎕RL",
+    "url": "language-reference-guide/system-functions/rl"
+  },
+  {
+    "symbol": "⎕RTL",
+    "url": "language-reference-guide/system-functions/rtl"
+  },
+  {
+    "symbol": "⎕WX",
+    "url": "language-reference-guide/system-functions/wx"
+  },
+  {
+    "symbol": "⎕USING",
+    "url": "language-reference-guide/system-functions/using"
+  },
+  {
+    "symbol": "⎕AVU",
+    "url": "language-reference-guide/system-functions/avu"
+  },
+  {
+    "symbol": "⎕DCT",
+    "url": "language-reference-guide/system-functions/dct"
+  },
+  {
+    "symbol": "⎕FR",
+    "url": "language-reference-guide/system-functions/fr"
+  },
+  {
+    "symbol": "Root",
+    "url": "object-reference/objects/root"
+  },
+  {
+    "symbol": "Form",
+    "url": "object-reference/objects/form"
+  },
+  {
+    "symbol": "Button",
+    "url": "object-reference/objects/button"
+  },
+  {
+    "symbol": "Static",
+    "url": "object-reference/objects/static"
+  },
+  {
+    "symbol": "Edit",
+    "url": "object-reference/objects/edit"
+  },
+  {
+    "symbol": "Label",
+    "url": "object-reference/objects/label"
+  },
+  {
+    "symbol": "MenuBar",
+    "url": "object-reference/objects/menubar"
+  },
+  {
+    "symbol": "Menu",
+    "url": "object-reference/objects/menu"
+  },
+  {
+    "symbol": "MenuItem",
+    "url": "object-reference/objects/menuitem"
+  },
+  {
+    "symbol": "Separator",
+    "url": "object-reference/objects/separator"
+  },
+  {
+    "symbol": "List",
+    "url": "object-reference/objects/list"
+  },
+  {
+    "symbol": "Group",
+    "url": "object-reference/objects/group"
+  },
+  {
+    "symbol": "Scroll",
+    "url": "object-reference/objects/scroll"
+  },
+  {
+    "symbol": "Combo",
+    "url": "object-reference/objects/combo"
+  },
+  {
+    "symbol": "SM",
+    "url": "object-reference/objects/sm"
+  },
+  {
+    "symbol": "MsgBox",
+    "url": "object-reference/objects/msgbox"
+  },
+  {
+    "symbol": "Font",
+    "url": "object-reference/objects/font"
+  },
+  {
+    "symbol": "FileBox",
+    "url": "object-reference/objects/filebox"
+  },
+  {
+    "symbol": "Poly",
+    "url": "object-reference/objects/poly"
+  },
+  {
+    "symbol": "Ellipse",
+    "url": "object-reference/objects/ellipse"
+  },
+  {
+    "symbol": "Circle",
+    "url": "object-reference/objects/circle"
+  },
+  {
+    "symbol": "Text",
+    "url": "object-reference/objects/text"
+  },
+  {
+    "symbol": "Rect",
+    "url": "object-reference/objects/rect"
+  },
+  {
+    "symbol": "Marker",
+    "url": "object-reference/objects/marker"
+  },
+  {
+    "symbol": "Printer",
+    "url": "object-reference/objects/printer"
+  },
+  {
+    "symbol": "Bitmap",
+    "url": "object-reference/objects/bitmap"
+  },
+  {
+    "symbol": "Icon",
+    "url": "object-reference/objects/icon"
+  },
+  {
+    "symbol": "Cursor",
+    "url": "object-reference/objects/cursor"
+  },
+  {
+    "symbol": "Image",
+    "url": "object-reference/objects/image"
+  },
+  {
+    "symbol": "Clipboard",
+    "url": "object-reference/objects/clipboard"
+  },
+  {
+    "symbol": "Locator",
+    "url": "object-reference/objects/locator"
+  },
+  {
+    "symbol": "Timer",
+    "url": "object-reference/objects/timer"
+  },
+  {
+    "symbol": "Metafile",
+    "url": "object-reference/objects/metafile"
+  },
+  {
+    "symbol": "MDIClient",
+    "url": "object-reference/objects/mdiclient"
+  },
+  {
+    "symbol": "ToolBar",
+    "url": "object-reference/objects/toolbar"
+  },
+  {
+    "symbol": "StatusBar",
+    "url": "object-reference/objects/statusbar"
+  },
+  {
+    "symbol": "StatusField",
+    "url": "object-reference/objects/statusfield"
+  },
+  {
+    "symbol": "TipField",
+    "url": "object-reference/objects/tipfield"
+  },
+  {
+    "symbol": "TabBtn",
+    "url": "object-reference/objects/tabbtn"
+  },
+  {
+    "symbol": "TabBar",
+    "url": "object-reference/objects/tabbar"
+  },
+  {
+    "symbol": "Grid",
+    "url": "object-reference/objects/grid"
+  },
+  {
+    "symbol": "SubForm",
+    "url": "object-reference/objects/subform"
+  },
+  {
+    "symbol": "TrackBar",
+    "url": "object-reference/objects/trackbar"
+  },
+  {
+    "symbol": "RichEdit",
+    "url": "object-reference/objects/richedit"
+  },
+  {
+    "symbol": "ProgressBar",
+    "url": "object-reference/objects/progressbar"
+  },
+  {
+    "symbol": "TreeView",
+    "url": "object-reference/objects/treeview"
+  },
+  {
+    "symbol": "ListView",
+    "url": "object-reference/objects/listview"
+  },
+  {
+    "symbol": "UpDown",
+    "url": "object-reference/objects/updown"
+  },
+  {
+    "symbol": "ImageList",
+    "url": "object-reference/objects/imagelist"
+  },
+  {
+    "symbol": "PropertySheet",
+    "url": "object-reference/objects/propertysheet"
+  },
+  {
+    "symbol": "PropertyPage",
+    "url": "object-reference/objects/propertypage"
+  },
+  {
+    "symbol": "Spinner",
+    "url": "object-reference/objects/spinner"
+  },
+  {
+    "symbol": "OCXClass",
+    "url": "object-reference/objects/ocxclass"
+  },
+  {
+    "symbol": "OLEServer",
+    "url": "object-reference/objects/oleserver"
+  },
+  {
+    "symbol": "OLEClient",
+    "url": "object-reference/objects/oleclient"
+  },
+  {
+    "symbol": "Class",
+    "url": "object-reference/objects/class"
+  },
+  {
+    "symbol": "Session",
+    "url": "object-reference/objects/session"
+  },
+  {
+    "symbol": "NameSpace",
+    "url": "object-reference/objects/namespace"
+  },
+  {
+    "symbol": "DragList",
+    "url": "object-reference/objects/draglist"
+  },
+  {
+    "symbol": "MMControl",
+    "url": "object-reference/objects/mmcontrol"
+  },
+  {
+    "symbol": "OCXControl",
+    "url": "object-reference/objects/ocxcontrol"
+  },
+  {
+    "symbol": "VBXControl",
+    "url": "object-reference/objects/vbxcontrol"
+  },
+  {
+    "symbol": "Interface",
+    "url": "object-reference/objects/interface"
+  },
+  {
+    "symbol": "ColorPicker",
+    "url": "object-reference/objects/colorpicker"
+  },
+  {
+    "symbol": "HotKeyControl",
+    "url": "object-reference/objects/hotkeycontrol"
+  },
+  {
+    "symbol": "SessionStatus",
+    "url": "object-reference/objects/sessionstatus"
+  },
+  {
+    "symbol": "SessionEditor",
+    "url": "object-reference/objects/sessioneditor"
+  },
+  {
+    "symbol": "SessionScriptCompiler",
+    "url": "object-reference/objects/sessionscriptcompiler"
+  },
+  {
+    "symbol": "FileWatcher",
+    "url": "object-reference/objects/filewatcher"
+  },
+  {
+    "symbol": "TCPSocket",
+    "url": "object-reference/objects/tcpsocket"
+  },
+  {
+    "symbol": "Splitter",
+    "url": "object-reference/objects/splitter"
+  },
+  {
+    "symbol": "CoolBar",
+    "url": "object-reference/objects/coolbar"
+  },
+  {
+    "symbol": "ToolControl",
+    "url": "object-reference/objects/toolcontrol"
+  },
+  {
+    "symbol": "ToolButton",
+    "url": "object-reference/objects/toolbutton"
+  },
+  {
+    "symbol": "SysTrayItem",
+    "url": "object-reference/objects/systrayitem"
+  },
+  {
+    "symbol": "TabControl",
+    "url": "object-reference/objects/tabcontrol"
+  },
+  {
+    "symbol": "TabButton",
+    "url": "object-reference/objects/tabbutton"
+  },
+  {
+    "symbol": "ColorButton",
+    "url": "object-reference/objects/colorbutton"
+  },
+  {
+    "symbol": "ActiveXContainer",
+    "url": "object-reference/objects/activexcontainer"
+  },
+  {
+    "symbol": "ActiveXControl",
+    "url": "object-reference/objects/activexcontrol"
+  },
+  {
+    "symbol": "CoolBand",
+    "url": "object-reference/objects/coolband"
+  },
+  {
+    "symbol": "Calendar",
+    "url": "object-reference/objects/calendar"
+  },
+  {
+    "symbol": "DateTimePicker",
+    "url": "object-reference/objects/datetimepicker"
+  },
+  {
+    "symbol": "ComboEx",
+    "url": "object-reference/objects/comboex"
+  },
+  {
+    "symbol": "BrowseBox",
+    "url": "object-reference/objects/browsebox"
+  },
+  {
+    "symbol": "Animation",
+    "url": "object-reference/objects/animation"
+  },
+  {
+    "symbol": "NetClient",
+    "url": "object-reference/objects/netclient"
+  },
+  {
+    "symbol": "NetType",
+    "url": "object-reference/objects/nettype"
+  },
+  {
+    "symbol": "NetControl",
+    "url": "object-reference/objects/netcontrol"
+  },
+  {
+    "symbol": "ButtonEdit",
+    "url": "object-reference/objects/buttonedit"
+  },
+  {
+    "symbol": "HTMLRenderer",
+    "url": "object-reference/objects/htmlrenderer"
+  },
+  {
+    "symbol": "MouseDown",
+    "url": "object-reference/methodorevents/mousedown"
+  },
+  {
+    "symbol": "MouseUp",
+    "url": "object-reference/methodorevents/mouseup"
+  },
+  {
+    "symbol": "MouseMove",
+    "url": "object-reference/methodorevents/mousemove"
+  },
+  {
+    "symbol": "MouseDblClick",
+    "url": "object-reference/methodorevents/mousedblclick"
+  },
+  {
+    "symbol": "MouseEnter",
+    "url": "object-reference/methodorevents/mouseenter"
+  },
+  {
+    "symbol": "MouseLeave",
+    "url": "object-reference/methodorevents/mouseleave"
+  },
+  {
+    "symbol": "MouseWheel",
+    "url": "object-reference/methodorevents/mousewheel"
+  },
+  {
+    "symbol": "DragOver",
+    "url": "object-reference/methodorevents/dragover"
+  },
+  {
+    "symbol": "DragDrop",
+    "url": "object-reference/methodorevents/dragdrop"
+  },
+  {
+    "symbol": "DragStart",
+    "url": "object-reference/methodorevents/dragstart"
+  },
+  {
+    "symbol": "DragListMove",
+    "url": "object-reference/methodorevents/draglistmove"
+  },
+  {
+    "symbol": "DragListCopy",
+    "url": "object-reference/methodorevents/draglistcopy"
+  },
+  {
+    "symbol": "KeyChar",
+    "url": "object-reference/methodorevents/keychar"
+  },
+  {
+    "symbol": "KeyDown",
+    "url": "object-reference/methodorevents/keydown"
+  },
+  {
+    "symbol": "KeyUp",
+    "url": "object-reference/methodorevents/keyup"
+  },
+  {
+    "symbol": "KeyPress",
+    "url": "object-reference/methodorevents/keypress"
+  },
+  {
+    "symbol": "KeyError",
+    "url": "object-reference/methodorevents/keyerror"
+  },
+  {
+    "symbol": "GridKeyPress",
+    "url": "object-reference/methodorevents/gridkeypress"
+  },
+  {
+    "symbol": "ShowSIP",
+    "url": "object-reference/methodorevents/showsip"
+  },
+  {
+    "symbol": "Animate",
+    "url": "object-reference/methodorevents/animate"
+  },
+  {
+    "symbol": "Select",
+    "url": "object-reference/methodorevents/select"
+  },
+  {
+    "symbol": "Configure",
+    "url": "object-reference/methodorevents/configure"
+  },
+  {
+    "symbol": "Expose",
+    "url": "object-reference/methodorevents/expose"
+  },
+  {
+    "symbol": "Close",
+    "url": "object-reference/methodorevents/close"
+  },
+  {
+    "symbol": "Create",
+    "url": "object-reference/methodorevents/create"
+  },
+  {
+    "symbol": "StateChange",
+    "url": "object-reference/methodorevents/statechange"
+  },
+  {
+    "symbol": "Change",
+    "url": "object-reference/methodorevents/change"
+  },
+  {
+    "symbol": "Scroll",
+    "url": "object-reference/methodorevents/scroll"
+  },
+  {
+    "symbol": "VScroll",
+    "url": "object-reference/methodorevents/vscroll"
+  },
+  {
+    "symbol": "HScroll",
+    "url": "object-reference/methodorevents/hscroll"
+  },
+  {
+    "symbol": "GotFocus",
+    "url": "object-reference/methodorevents/gotfocus"
+  },
+  {
+    "symbol": "LostFocus",
+    "url": "object-reference/methodorevents/lostfocus"
+  },
+  {
+    "symbol": "MDIActivate",
+    "url": "object-reference/methodorevents/mdiactivate"
+  },
+  {
+    "symbol": "MDIDeactivate",
+    "url": "object-reference/methodorevents/mdideactivate"
+  },
+  {
+    "symbol": "DropDown",
+    "url": "object-reference/methodorevents/dropdown"
+  },
+  {
+    "symbol": "CloseUp",
+    "url": "object-reference/methodorevents/closeup"
+  },
+  {
+    "symbol": "DDE",
+    "url": "object-reference/methodorevents/dde"
+  },
+  {
+    "symbol": "MsgBtn1",
+    "url": "object-reference/methodorevents/msgbtn1"
+  },
+  {
+    "symbol": "MsgBtn2",
+    "url": "object-reference/methodorevents/msgbtn2"
+  },
+  {
+    "symbol": "MsgBtn3",
+    "url": "object-reference/methodorevents/msgbtn3"
+  },
+  {
+    "symbol": "FileBoxOK",
+    "url": "object-reference/methodorevents/fileboxok"
+  },
+  {
+    "symbol": "FileBoxCancel",
+    "url": "object-reference/methodorevents/fileboxcancel"
+  },
+  {
+    "symbol": "Locator",
+    "url": "object-reference/methodorevents/locator"
+  },
+  {
+    "symbol": "FileRead",
+    "url": "object-reference/methodorevents/fileread"
+  },
+  {
+    "symbol": "FileWrite",
+    "url": "object-reference/methodorevents/filewrite"
+  },
+  {
+    "symbol": "GetServiceState",
+    "url": "object-reference/methodorevents/getservicestate"
+  },
+  {
+    "symbol": "SetServiceState",
+    "url": "object-reference/methodorevents/setservicestate"
+  },
+  {
+    "symbol": "ServiceNotification",
+    "url": "object-reference/methodorevents/servicenotification"
+  },
+  {
+    "symbol": "DyalogCustomMessage1",
+    "url": "object-reference/methodorevents/dyalogcustommessage1"
+  },
+  {
+    "symbol": "Print",
+    "url": "object-reference/methodorevents/print"
+  },
+  {
+    "symbol": "Setup",
+    "url": "object-reference/methodorevents/setup"
+  },
+  {
+    "symbol": "NewPage",
+    "url": "object-reference/methodorevents/newpage"
+  },
+  {
+    "symbol": "Abort",
+    "url": "object-reference/methodorevents/abort"
+  },
+  {
+    "symbol": "MDICascade",
+    "url": "object-reference/methodorevents/mdicascade"
+  },
+  {
+    "symbol": "MDITile",
+    "url": "object-reference/methodorevents/mditile"
+  },
+  {
+    "symbol": "MDIArrange",
+    "url": "object-reference/methodorevents/mdiarrange"
+  },
+  {
+    "symbol": "ClipChange",
+    "url": "object-reference/methodorevents/clipchange"
+  },
+  {
+    "symbol": "Idle",
+    "url": "object-reference/methodorevents/idle"
+  },
+  {
+    "symbol": "ExitWindows",
+    "url": "object-reference/methodorevents/exitwindows"
+  },
+  {
+    "symbol": "ExitApp",
+    "url": "object-reference/methodorevents/exitapp"
+  },
+  {
+    "symbol": "WinIniChange",
+    "url": "object-reference/methodorevents/wininichange"
+  },
+  {
+    "symbol": "SysColorChange",
+    "url": "object-reference/methodorevents/syscolorchange"
+  },
+  {
+    "symbol": "Flush",
+    "url": "object-reference/methodorevents/flush"
+  },
+  {
+    "symbol": "NameFromHandle",
+    "url": "object-reference/methodorevents/namefromhandle"
+  },
+  {
+    "symbol": "DisplayChange",
+    "url": "object-reference/methodorevents/displaychange"
+  },
+  {
+    "symbol": "GreetBitmap",
+    "url": "object-reference/methodorevents/greetbitmap"
+  },
+  {
+    "symbol": "ActivateApp",
+    "url": "object-reference/methodorevents/activateapp"
+  },
+  {
+    "symbol": "Timer",
+    "url": "object-reference/methodorevents/timer"
+  },
+  {
+    "symbol": "GetCommandLine",
+    "url": "object-reference/methodorevents/getcommandline"
+  },
+  {
+    "symbol": "GetTextSize",
+    "url": "object-reference/methodorevents/gettextsize"
+  },
+  {
+    "symbol": "Wait",
+    "url": "object-reference/methodorevents/wait"
+  },
+  {
+    "symbol": "GetCommandLineArgs",
+    "url": "object-reference/methodorevents/getcommandlineargs"
+  },
+  {
+    "symbol": "CellChange",
+    "url": "object-reference/methodorevents/cellchange"
+  },
+  {
+    "symbol": "CellMove",
+    "url": "object-reference/methodorevents/cellmove"
+  },
+  {
+    "symbol": "AddRow",
+    "url": "object-reference/methodorevents/addrow"
+  },
+  {
+    "symbol": "AddCol",
+    "url": "object-reference/methodorevents/addcol"
+  },
+  {
+    "symbol": "DelRow",
+    "url": "object-reference/methodorevents/delrow"
+  },
+  {
+    "symbol": "DelCol",
+    "url": "object-reference/methodorevents/delcol"
+  },
+  {
+    "symbol": "SetCellType",
+    "url": "object-reference/methodorevents/setcelltype"
+  },
+  {
+    "symbol": "CellError",
+    "url": "object-reference/methodorevents/cellerror"
+  },
+  {
+    "symbol": "RowChange",
+    "url": "object-reference/methodorevents/rowchange"
+  },
+  {
+    "symbol": "ColChange",
+    "url": "object-reference/methodorevents/colchange"
+  },
+  {
+    "symbol": "CellOver",
+    "url": "object-reference/methodorevents/cellover"
+  },
+  {
+    "symbol": "CellDown",
+    "url": "object-reference/methodorevents/celldown"
+  },
+  {
+    "symbol": "CellUp",
+    "url": "object-reference/methodorevents/cellup"
+  },
+  {
+    "symbol": "CellDblClick",
+    "url": "object-reference/methodorevents/celldblclick"
+  },
+  {
+    "symbol": "CellChanged",
+    "url": "object-reference/methodorevents/cellchanged"
+  },
+  {
+    "symbol": "GridSelect",
+    "url": "object-reference/methodorevents/gridselect"
+  },
+  {
+    "symbol": "Undo",
+    "url": "object-reference/methodorevents/undo"
+  },
+  {
+    "symbol": "SetCellSet",
+    "url": "object-reference/methodorevents/setcellset"
+  },
+  {
+    "symbol": "RowSetVisibleDepth",
+    "url": "object-reference/methodorevents/rowsetvisibledepth"
+  },
+  {
+    "symbol": "ColSorted",
+    "url": "object-reference/methodorevents/colsorted"
+  },
+  {
+    "symbol": "SetRowSize",
+    "url": "object-reference/methodorevents/setrowsize"
+  },
+  {
+    "symbol": "SetColSize",
+    "url": "object-reference/methodorevents/setcolsize"
+  },
+  {
+    "symbol": "DuplicateRow",
+    "url": "object-reference/methodorevents/duplicaterow"
+  },
+  {
+    "symbol": "DuplicateColumn",
+    "url": "object-reference/methodorevents/duplicatecolumn"
+  },
+  {
+    "symbol": "BadValue",
+    "url": "object-reference/methodorevents/badvalue"
+  },
+  {
+    "symbol": "GridCut",
+    "url": "object-reference/methodorevents/gridcut"
+  },
+  {
+    "symbol": "GridCopy",
+    "url": "object-reference/methodorevents/gridcopy"
+  },
+  {
+    "symbol": "GridPaste",
+    "url": "object-reference/methodorevents/gridpaste"
+  },
+  {
+    "symbol": "GridDelete",
+    "url": "object-reference/methodorevents/griddelete"
+  },
+  {
+    "symbol": "GridPasteError",
+    "url": "object-reference/methodorevents/gridpasteerror"
+  },
+  {
+    "symbol": "GridDropSel",
+    "url": "object-reference/methodorevents/griddropsel"
+  },
+  {
+    "symbol": "GridCopyError",
+    "url": "object-reference/methodorevents/gridcopyerror"
+  },
+  {
+    "symbol": "CellFromPoint",
+    "url": "object-reference/methodorevents/cellfrompoint"
+  },
+  {
+    "symbol": "GetCellRect",
+    "url": "object-reference/methodorevents/getcellrect"
+  },
+  {
+    "symbol": "IndexChanged",
+    "url": "object-reference/methodorevents/indexchanged"
+  },
+  {
+    "symbol": "AddComment",
+    "url": "object-reference/methodorevents/addcomment"
+  },
+  {
+    "symbol": "DelComment",
+    "url": "object-reference/methodorevents/delcomment"
+  },
+  {
+    "symbol": "GetComment",
+    "url": "object-reference/methodorevents/getcomment"
+  },
+  {
+    "symbol": "ShowComment",
+    "url": "object-reference/methodorevents/showcomment"
+  },
+  {
+    "symbol": "HideComment",
+    "url": "object-reference/methodorevents/hidecomment"
+  },
+  {
+    "symbol": "ClickComment",
+    "url": "object-reference/methodorevents/clickcomment"
+  },
+  {
+    "symbol": "LockRows",
+    "url": "object-reference/methodorevents/lockrows"
+  },
+  {
+    "symbol": "LockColumns",
+    "url": "object-reference/methodorevents/lockcolumns"
+  },
+  {
+    "symbol": "HideRows",
+    "url": "object-reference/methodorevents/hiderows"
+  },
+  {
+    "symbol": "HideColumns",
+    "url": "object-reference/methodorevents/hidecolumns"
+  },
+  {
+    "symbol": "ProtectRows",
+    "url": "object-reference/methodorevents/protectrows"
+  },
+  {
+    "symbol": "ProtectColumns",
+    "url": "object-reference/methodorevents/protectcolumns"
+  },
+  {
+    "symbol": "ChooseFont",
+    "url": "object-reference/methodorevents/choosefont"
+  },
+  {
+    "symbol": "FontOK",
+    "url": "object-reference/methodorevents/fontok"
+  },
+  {
+    "symbol": "FontCancel",
+    "url": "object-reference/methodorevents/fontcancel"
+  },
+  {
+    "symbol": "ProgressStep",
+    "url": "object-reference/methodorevents/progressstep"
+  },
+  {
+    "symbol": "MakePNG",
+    "url": "object-reference/methodorevents/makepng"
+  },
+  {
+    "symbol": "MakeGIF",
+    "url": "object-reference/methodorevents/makegif"
+  },
+  {
+    "symbol": "GetVisibleRange",
+    "url": "object-reference/methodorevents/getvisiblerange"
+  },
+  {
+    "symbol": "IDNToDate",
+    "url": "object-reference/methodorevents/idntodate"
+  },
+  {
+    "symbol": "DateToIDN",
+    "url": "object-reference/methodorevents/datetoidn"
+  },
+  {
+    "symbol": "SelDateChange",
+    "url": "object-reference/methodorevents/seldatechange"
+  },
+  {
+    "symbol": "GetDayStates",
+    "url": "object-reference/methodorevents/getdaystates"
+  },
+  {
+    "symbol": "DateTimeChange",
+    "url": "object-reference/methodorevents/datetimechange"
+  },
+  {
+    "symbol": "Detach",
+    "url": "object-reference/methodorevents/detach"
+  },
+  {
+    "symbol": "CalendarDown",
+    "url": "object-reference/methodorevents/calendardown"
+  },
+  {
+    "symbol": "CalendarUp",
+    "url": "object-reference/methodorevents/calendarup"
+  },
+  {
+    "symbol": "CalendarDblClick",
+    "url": "object-reference/methodorevents/calendardblclick"
+  },
+  {
+    "symbol": "CalendarMove",
+    "url": "object-reference/methodorevents/calendarmove"
+  },
+  {
+    "symbol": "GetMinSize",
+    "url": "object-reference/methodorevents/getminsize"
+  },
+  {
+    "symbol": "StartSplit",
+    "url": "object-reference/methodorevents/startsplit"
+  },
+  {
+    "symbol": "Splitting",
+    "url": "object-reference/methodorevents/splitting"
+  },
+  {
+    "symbol": "EndSplit",
+    "url": "object-reference/methodorevents/endsplit"
+  },
+  {
+    "symbol": "AnimOpen",
+    "url": "object-reference/methodorevents/animopen"
+  },
+  {
+    "symbol": "AnimClose",
+    "url": "object-reference/methodorevents/animclose"
+  },
+  {
+    "symbol": "AnimPlay",
+    "url": "object-reference/methodorevents/animplay"
+  },
+  {
+    "symbol": "AnimStop",
+    "url": "object-reference/methodorevents/animstop"
+  },
+  {
+    "symbol": "AnimStarted",
+    "url": "object-reference/methodorevents/animstarted"
+  },
+  {
+    "symbol": "AnimStopped",
+    "url": "object-reference/methodorevents/animstopped"
+  },
+  {
+    "symbol": "BeginEditLabel",
+    "url": "object-reference/methodorevents/begineditlabel"
+  },
+  {
+    "symbol": "EndEditLabel",
+    "url": "object-reference/methodorevents/endeditlabel"
+  },
+  {
+    "symbol": "Expanding",
+    "url": "object-reference/methodorevents/expanding"
+  },
+  {
+    "symbol": "Retracting",
+    "url": "object-reference/methodorevents/retracting"
+  },
+  {
+    "symbol": "GetItemState",
+    "url": "object-reference/methodorevents/getitemstate"
+  },
+  {
+    "symbol": "SetItemState",
+    "url": "object-reference/methodorevents/setitemstate"
+  },
+  {
+    "symbol": "AddItems",
+    "url": "object-reference/methodorevents/additems"
+  },
+  {
+    "symbol": "DeleteItems",
+    "url": "object-reference/methodorevents/deleteitems"
+  },
+  {
+    "symbol": "AddChildren",
+    "url": "object-reference/methodorevents/addchildren"
+  },
+  {
+    "symbol": "DeleteChildren",
+    "url": "object-reference/methodorevents/deletechildren"
+  },
+  {
+    "symbol": "GetParentItem",
+    "url": "object-reference/methodorevents/getparentitem"
+  },
+  {
+    "symbol": "GetItemHandle",
+    "url": "object-reference/methodorevents/getitemhandle"
+  },
+  {
+    "symbol": "SetItemImage",
+    "url": "object-reference/methodorevents/setitemimage"
+  },
+  {
+    "symbol": "ShowItem",
+    "url": "object-reference/methodorevents/showitem"
+  },
+  {
+    "symbol": "ColumnClick",
+    "url": "object-reference/methodorevents/columnclick"
+  },
+  {
+    "symbol": "SetItemPosition",
+    "url": "object-reference/methodorevents/setitemposition"
+  },
+  {
+    "symbol": "GetItemPosition",
+    "url": "object-reference/methodorevents/getitemposition"
+  },
+  {
+    "symbol": "GetTipText",
+    "url": "object-reference/methodorevents/gettiptext"
+  },
+  {
+    "symbol": "ItemDown",
+    "url": "object-reference/methodorevents/itemdown"
+  },
+  {
+    "symbol": "ItemUp",
+    "url": "object-reference/methodorevents/itemup"
+  },
+  {
+    "symbol": "ItemDblClick",
+    "url": "object-reference/methodorevents/itemdblclick"
+  },
+  {
+    "symbol": "PageApply",
+    "url": "object-reference/methodorevents/pageapply"
+  },
+  {
+    "symbol": "PageCancel",
+    "url": "object-reference/methodorevents/pagecancel"
+  },
+  {
+    "symbol": "PageHelp",
+    "url": "object-reference/methodorevents/pagehelp"
+  },
+  {
+    "symbol": "PageBack",
+    "url": "object-reference/methodorevents/pageback"
+  },
+  {
+    "symbol": "PageNext",
+    "url": "object-reference/methodorevents/pagenext"
+  },
+  {
+    "symbol": "PageFinish",
+    "url": "object-reference/methodorevents/pagefinish"
+  },
+  {
+    "symbol": "PageChanged",
+    "url": "object-reference/methodorevents/pagechanged"
+  },
+  {
+    "symbol": "PageActivate",
+    "url": "object-reference/methodorevents/pageactivate"
+  },
+  {
+    "symbol": "PageDeactivate",
+    "url": "object-reference/methodorevents/pagedeactivate"
+  },
+  {
+    "symbol": "SetWizard",
+    "url": "object-reference/methodorevents/setwizard"
+  },
+  {
+    "symbol": "SetFinishText",
+    "url": "object-reference/methodorevents/setfinishtext"
+  },
+  {
+    "symbol": "CancelToClose",
+    "url": "object-reference/methodorevents/canceltoclose"
+  },
+  {
+    "symbol": "TCPError",
+    "url": "object-reference/methodorevents/tcperror"
+  },
+  {
+    "symbol": "TCPAccept",
+    "url": "object-reference/methodorevents/tcpaccept"
+  },
+  {
+    "symbol": "TCPConnect",
+    "url": "object-reference/methodorevents/tcpconnect"
+  },
+  {
+    "symbol": "TCPRecv",
+    "url": "object-reference/methodorevents/tcprecv"
+  },
+  {
+    "symbol": "TCPClose",
+    "url": "object-reference/methodorevents/tcpclose"
+  },
+  {
+    "symbol": "TCPSend",
+    "url": "object-reference/methodorevents/tcpsend"
+  },
+  {
+    "symbol": "TCPGetHostID",
+    "url": "object-reference/methodorevents/tcpgethostid"
+  },
+  {
+    "symbol": "TCPGotAddr",
+    "url": "object-reference/methodorevents/tcpgotaddr"
+  },
+  {
+    "symbol": "TCPGotPort",
+    "url": "object-reference/methodorevents/tcpgotport"
+  },
+  {
+    "symbol": "TCPReady",
+    "url": "object-reference/methodorevents/tcpready"
+  },
+  {
+    "symbol": "TCPSendPicture",
+    "url": "object-reference/methodorevents/tcpsendpicture"
+  },
+  {
+    "symbol": "MMOpen",
+    "url": "object-reference/methodorevents/mmopen"
+  },
+  {
+    "symbol": "MMClose",
+    "url": "object-reference/methodorevents/mmclose"
+  },
+  {
+    "symbol": "MMPlay",
+    "url": "object-reference/methodorevents/mmplay"
+  },
+  {
+    "symbol": "MMStop",
+    "url": "object-reference/methodorevents/mmstop"
+  },
+  {
+    "symbol": "MMReverse",
+    "url": "object-reference/methodorevents/mmreverse"
+  },
+  {
+    "symbol": "GetMMError",
+    "url": "object-reference/methodorevents/getmmerror"
+  },
+  {
+    "symbol": "MMError",
+    "url": "object-reference/methodorevents/mmerror"
+  },
+  {
+    "symbol": "MMMediaChanged",
+    "url": "object-reference/methodorevents/mmmediachanged"
+  },
+  {
+    "symbol": "MMModeChanged",
+    "url": "object-reference/methodorevents/mmmodechanged"
+  },
+  {
+    "symbol": "MMPosChanged",
+    "url": "object-reference/methodorevents/mmposchanged"
+  },
+  {
+    "symbol": "Help",
+    "url": "object-reference/methodorevents/help"
+  },
+  {
+    "symbol": "MMSizeChanged",
+    "url": "object-reference/methodorevents/mmsizechanged"
+  },
+  {
+    "symbol": "MMOpenDialog",
+    "url": "object-reference/methodorevents/mmopendialog"
+  },
+  {
+    "symbol": "MMEject",
+    "url": "object-reference/methodorevents/mmeject"
+  },
+  {
+    "symbol": "MMCurPos",
+    "url": "object-reference/properties/mmcurpos"
+  },
+  {
+    "symbol": "MMCurPosString",
+    "url": "object-reference/properties/mmcurposstring"
+  },
+  {
+    "symbol": "MMCurMode",
+    "url": "object-reference/properties/mmcurmode"
+  },
+  {
+    "symbol": "SendString",
+    "url": "object-reference/methodorevents/sendstring"
+  },
+  {
+    "symbol": "ReceiveString",
+    "url": "object-reference/methodorevents/receivestring"
+  },
+  {
+    "symbol": "ContextMenu",
+    "url": "object-reference/methodorevents/contextmenu"
+  },
+  {
+    "symbol": "FrameContextMenu",
+    "url": "object-reference/methodorevents/framecontextmenu"
+  },
+  {
+    "symbol": "Spin",
+    "url": "object-reference/methodorevents/spin"
+  },
+  {
+    "symbol": "SetSpinnerText",
+    "url": "object-reference/methodorevents/setspinnertext"
+  },
+  {
+    "symbol": "ColorChange",
+    "url": "object-reference/methodorevents/colorchange"
+  },
+  {
+    "symbol": "ThumbDrag",
+    "url": "object-reference/methodorevents/thumbdrag"
+  },
+  {
+    "symbol": "VThumbDrag",
+    "url": "object-reference/methodorevents/vthumbdrag"
+  },
+  {
+    "symbol": "HThumbDrag",
+    "url": "object-reference/methodorevents/hthumbdrag"
+  },
+  {
+    "symbol": "DropFiles",
+    "url": "object-reference/methodorevents/dropfiles"
+  },
+  {
+    "symbol": "DropObjects",
+    "url": "object-reference/methodorevents/dropobjects"
+  },
+  {
+    "symbol": "RTFPrintSetup",
+    "url": "object-reference/methodorevents/rtfprintsetup"
+  },
+  {
+    "symbol": "RTFPrint",
+    "url": "object-reference/methodorevents/rtfprint"
+  },
+  {
+    "symbol": "Protected",
+    "url": "object-reference/methodorevents/protected"
+  },
+  {
+    "symbol": "DockStart",
+    "url": "object-reference/methodorevents/dockstart"
+  },
+  {
+    "symbol": "DockMove",
+    "url": "object-reference/methodorevents/dockmove"
+  },
+  {
+    "symbol": "DockRequest",
+    "url": "object-reference/methodorevents/dockrequest"
+  },
+  {
+    "symbol": "DockAccept",
+    "url": "object-reference/methodorevents/dockaccept"
+  },
+  {
+    "symbol": "DockEnd",
+    "url": "object-reference/methodorevents/dockend"
+  },
+  {
+    "symbol": "DockCancel",
+    "url": "object-reference/methodorevents/dockcancel"
+  },
+  {
+    "symbol": "Gesture",
+    "url": "object-reference/methodorevents/gesture"
+  },
+  {
+    "symbol": "GestureBegin",
+    "url": "object-reference/methodorevents/gesturebegin"
+  },
+  {
+    "symbol": "GestureEnd",
+    "url": "object-reference/methodorevents/gestureend"
+  },
+  {
+    "symbol": "GestureZoom",
+    "url": "object-reference/methodorevents/gesturezoom"
+  },
+  {
+    "symbol": "GesturePan",
+    "url": "object-reference/methodorevents/gesturepan"
+  },
+  {
+    "symbol": "GestureRotate",
+    "url": "object-reference/methodorevents/gesturerotate"
+  },
+  {
+    "symbol": "GestureTwoFingerTap",
+    "url": "object-reference/methodorevents/gesturetwofingertap"
+  },
+  {
+    "symbol": "GesturePressAndTap",
+    "url": "object-reference/methodorevents/gesturepressandtap"
+  },
+  {
+    "symbol": "VBXRefresh",
+    "url": "object-reference/methodorevents/vbxrefresh"
+  },
+  {
+    "symbol": "VBXMove",
+    "url": "object-reference/methodorevents/vbxmove"
+  },
+  {
+    "symbol": "VBXAddItem",
+    "url": "object-reference/methodorevents/vbxadditem"
+  },
+  {
+    "symbol": "VBXRemove",
+    "url": "object-reference/methodorevents/vbxremove"
+  },
+  {
+    "symbol": "GetFocusObj",
+    "url": "object-reference/methodorevents/getfocusobj"
+  },
+  {
+    "symbol": "GetEnvironment",
+    "url": "object-reference/methodorevents/getenvironment"
+  },
+  {
+    "symbol": "GetFocus",
+    "url": "object-reference/methodorevents/getfocus"
+  },
+  {
+    "symbol": "ListTypeLibs",
+    "url": "object-reference/methodorevents/listtypelibs"
+  },
+  {
+    "symbol": "DeleteTypeLib",
+    "url": "object-reference/methodorevents/deletetypelib"
+  },
+  {
+    "symbol": "WorkspaceLoaded",
+    "url": "object-reference/methodorevents/workspaceloaded"
+  },
+  {
+    "symbol": "SessionPrint",
+    "url": "object-reference/methodorevents/sessionprint"
+  },
+  {
+    "symbol": "OLERegister",
+    "url": "object-reference/methodorevents/oleregister"
+  },
+  {
+    "symbol": "OLEUnregister",
+    "url": "object-reference/methodorevents/oleunregister"
+  },
+  {
+    "symbol": "AmbientChanged",
+    "url": "object-reference/methodorevents/ambientchanged"
+  },
+  {
+    "symbol": "PreCreate",
+    "url": "object-reference/methodorevents/precreate"
+  },
+  {
+    "symbol": "OLEAddEventSink",
+    "url": "object-reference/methodorevents/oleaddeventsink"
+  },
+  {
+    "symbol": "OLEDeleteEventSink",
+    "url": "object-reference/methodorevents/oledeleteeventsink"
+  },
+  {
+    "symbol": "OLEListEventSinks",
+    "url": "object-reference/methodorevents/olelisteventsinks"
+  },
+  {
+    "symbol": "OLEQueryInterface",
+    "url": "object-reference/methodorevents/olequeryinterface"
+  },
+  {
+    "symbol": "SetFnInfo",
+    "url": "object-reference/methodorevents/setfninfo"
+  },
+  {
+    "symbol": "SetVarInfo",
+    "url": "object-reference/methodorevents/setvarinfo"
+  },
+  {
+    "symbol": "SetEventInfo",
+    "url": "object-reference/methodorevents/seteventinfo"
+  },
+  {
+    "symbol": "GetAllEvents",
+    "url": "object-reference/methodorevents/getallevents"
+  },
+  {
+    "symbol": "GetPropertyInfo",
+    "url": "object-reference/methodorevents/getpropertyinfo"
+  },
+  {
+    "symbol": "GetEventInfo",
+    "url": "object-reference/methodorevents/geteventinfo"
+  },
+  {
+    "symbol": "GetMethodInfo",
+    "url": "object-reference/methodorevents/getmethodinfo"
+  },
+  {
+    "symbol": "GetTypeInfo",
+    "url": "object-reference/methodorevents/gettypeinfo"
+  },
+  {
+    "symbol": "SetPropertyInfo",
+    "url": "object-reference/methodorevents/setpropertyinfo"
+  },
+  {
+    "symbol": "SetMethodInfo",
+    "url": "object-reference/methodorevents/setmethodinfo"
+  },
+  {
+    "symbol": "ShowProperties",
+    "url": "object-reference/methodorevents/showproperties"
+  },
+  {
+    "symbol": "ShowHelp",
+    "url": "object-reference/methodorevents/showhelp"
+  },
+  {
+    "symbol": "Browse",
+    "url": "object-reference/methodorevents/browse"
+  },
+  {
+    "symbol": "ShowVerbMenu",
+    "url": "object-reference/methodorevents/showverbmenu"
+  },
+  {
+    "symbol": "DeletePropertyInfo",
+    "url": "object-reference/methodorevents/deletepropertyinfo"
+  },
+  {
+    "symbol": "DeleteEventInfo",
+    "url": "object-reference/methodorevents/deleteeventinfo"
+  },
+  {
+    "symbol": "DeleteMethodInfo",
+    "url": "object-reference/methodorevents/deletemethodinfo"
+  },
+  {
+    "symbol": "Bind",
+    "url": "object-reference/methodorevents/bind"
+  },
+  {
+    "symbol": "BaseConstructor",
+    "url": "object-reference/methodorevents/baseconstructor"
+  },
+  {
+    "symbol": "As",
+    "url": "object-reference/methodorevents/as"
+  },
+  {
+    "symbol": "SetFieldInfo",
+    "url": "object-reference/methodorevents/setfieldinfo"
+  },
+  {
+    "symbol": "GetFieldInfo",
+    "url": "object-reference/methodorevents/getfieldinfo"
+  },
+  {
+    "symbol": "Clear",
+    "url": "object-reference/methodorevents/clear"
+  },
+  {
+    "symbol": "AddText",
+    "url": "object-reference/methodorevents/addtext"
+  },
+  {
+    "symbol": "AddLine",
+    "url": "object-reference/methodorevents/addline"
+  },
+  {
+    "symbol": "Fix",
+    "url": "object-reference/methodorevents/fix"
+  },
+  {
+    "symbol": "Format",
+    "url": "object-reference/methodorevents/format"
+  },
+  {
+    "symbol": "AfterFix",
+    "url": "object-reference/methodorevents/afterfix"
+  },
+  {
+    "symbol": "HTTPRequest",
+    "url": "object-reference/methodorevents/httprequest"
+  },
+  {
+    "symbol": "WebSocketUpgrade",
+    "url": "object-reference/methodorevents/websocketupgrade"
+  },
+  {
+    "symbol": "WebSocketReceive",
+    "url": "object-reference/methodorevents/websocketreceive"
+  },
+  {
+    "symbol": "WebSocketClose",
+    "url": "object-reference/methodorevents/websocketclose"
+  },
+  {
+    "symbol": "WebSocketError",
+    "url": "object-reference/methodorevents/websocketerror"
+  },
+  {
+    "symbol": "PrintToPDF",
+    "url": "object-reference/methodorevents/printtopdf"
+  },
+  {
+    "symbol": "DoPopup",
+    "url": "object-reference/methodorevents/dopopup"
+  },
+  {
+    "symbol": "ExecuteJavaScript",
+    "url": "object-reference/methodorevents/executejavascript"
+  },
+  {
+    "symbol": "WebSocketSend",
+    "url": "object-reference/methodorevents/websocketsend"
+  },
+  {
+    "symbol": "SelectCertificate",
+    "url": "object-reference/methodorevents/selectcertificate"
+  },
+  {
+    "symbol": "ShowDevTools",
+    "url": "object-reference/methodorevents/showdevtools"
+  },
+  {
+    "symbol": "SetInputEncoding",
+    "url": "object-reference/methodorevents/setinputencoding"
+  },
+  {
+    "symbol": "SetOutputEncoding",
+    "url": "object-reference/methodorevents/setoutputencoding"
+  },
+  {
+    "symbol": "ShowBalloonTip",
+    "url": "object-reference/methodorevents/showballoontip"
+  },
+  {
+    "symbol": "BalloonShow",
+    "url": "object-reference/methodorevents/balloonshow"
+  },
+  {
+    "symbol": "BalloonHide",
+    "url": "object-reference/methodorevents/balloonhide"
+  },
+  {
+    "symbol": "BalloonTimeout",
+    "url": "object-reference/methodorevents/balloontimeout"
+  },
+  {
+    "symbol": "BalloonUserClick",
+    "url": "object-reference/methodorevents/balloonuserclick"
+  },
+  {
+    "symbol": "GetBuildID",
+    "url": "object-reference/methodorevents/getbuildid"
+  },
+  {
+    "symbol": "wscheck",
+    "url": "object-reference/methodorevents/wscheck"
+  },
+  {
+    "symbol": "SetDFlags",
+    "url": "object-reference/methodorevents/setdflags"
+  },
+  {
+    "symbol": "DumpWS",
+    "url": "object-reference/methodorevents/dumpws"
+  },
+  {
+    "symbol": "RefixWS",
+    "url": "object-reference/methodorevents/refixws"
+  },
+  {
+    "symbol": "DumpWindows",
+    "url": "object-reference/methodorevents/dumpwindows"
+  },
+  {
+    "symbol": "CoreDump",
+    "url": "object-reference/methodorevents/coredump"
+  },
+  {
+    "symbol": "DockSessionItem",
+    "url": "object-reference/methodorevents/docksessionitem"
+  },
+  {
+    "symbol": "CloseSessionItem",
+    "url": "object-reference/methodorevents/closesessionitem"
+  },
+  {
+    "symbol": "Type",
+    "url": "object-reference/properties/type"
+  },
+  {
+    "symbol": "Caption",
+    "url": "object-reference/properties/caption"
+  },
+  {
+    "symbol": "SplitObj1",
+    "url": "object-reference/properties/splitobj1"
+  },
+  {
+    "symbol": "SplitObj2",
+    "url": "object-reference/properties/splitobj2"
+  },
+  {
+    "symbol": "HTML",
+    "url": "object-reference/properties/html"
+  },
+  {
+    "symbol": "Values",
+    "url": "object-reference/properties/values"
+  },
+  {
+    "symbol": "PName",
+    "url": "object-reference/properties/pname"
+  },
+  {
+    "symbol": "BaseClass",
+    "url": "object-reference/properties/baseclass"
+  },
+  {
+    "symbol": "ClassName",
+    "url": "object-reference/properties/classname"
+  },
+  {
+    "symbol": "ConstructorArgs",
+    "url": "object-reference/properties/constructorargs"
+  },
+  {
+    "symbol": "Interfaces",
+    "url": "object-reference/properties/interfaces"
+  },
+  {
+    "symbol": "Interval",
+    "url": "object-reference/properties/interval"
+  },
+  {
+    "symbol": "FireOnce",
+    "url": "object-reference/properties/fireonce"
+  },
+  {
+    "symbol": "Items",
+    "url": "object-reference/properties/items"
+  },
+  {
+    "symbol": "Text",
+    "url": "object-reference/properties/text"
+  },
+  {
+    "symbol": "Posn",
+    "url": "object-reference/properties/posn"
+  },
+  {
+    "symbol": "Points",
+    "url": "object-reference/properties/points"
+  },
+  {
+    "symbol": "Style",
+    "url": "object-reference/properties/style"
+  },
+  {
+    "symbol": "Size",
+    "url": "object-reference/properties/size"
+  },
+  {
+    "symbol": "URL",
+    "url": "object-reference/properties/url"
+  },
+  {
+    "symbol": "CurrentColor",
+    "url": "object-reference/properties/currentcolor"
+  },
+  {
+    "symbol": "DefaultColors",
+    "url": "object-reference/properties/defaultcolors"
+  },
+  {
+    "symbol": "CustomColors",
+    "url": "object-reference/properties/customcolors"
+  },
+  {
+    "symbol": "OtherButton",
+    "url": "object-reference/properties/otherbutton"
+  },
+  {
+    "symbol": "Radius",
+    "url": "object-reference/properties/radius"
+  },
+  {
+    "symbol": "FCol",
+    "url": "object-reference/properties/fcol"
+  },
+  {
+    "symbol": "BCol",
+    "url": "object-reference/properties/bcol"
+  },
+  {
+    "symbol": "Start",
+    "url": "object-reference/properties/start"
+  },
+  {
+    "symbol": "End",
+    "url": "object-reference/properties/end"
+  },
+  {
+    "symbol": "ArcMode",
+    "url": "object-reference/properties/arcmode"
+  },
+  {
+    "symbol": "LStyle",
+    "url": "object-reference/properties/lstyle"
+  },
+  {
+    "symbol": "LWidth",
+    "url": "object-reference/properties/lwidth"
+  },
+  {
+    "symbol": "FStyle",
+    "url": "object-reference/properties/fstyle"
+  },
+  {
+    "symbol": "FillCol",
+    "url": "object-reference/properties/fillcol"
+  },
+  {
+    "symbol": "FBCol",
+    "url": "object-reference/properties/fbcol"
+  },
+  {
+    "symbol": "DevCaps",
+    "url": "object-reference/properties/devcaps"
+  },
+  {
+    "symbol": "VAlign",
+    "url": "object-reference/properties/valign"
+  },
+  {
+    "symbol": "HAlign",
+    "url": "object-reference/properties/halign"
+  },
+  {
+    "symbol": "Directory",
+    "url": "object-reference/properties/directory"
+  },
+  {
+    "symbol": "BrowseFor",
+    "url": "object-reference/properties/browsefor"
+  },
+  {
+    "symbol": "Target",
+    "url": "object-reference/properties/target"
+  },
+  {
+    "symbol": "StartIn",
+    "url": "object-reference/properties/startin"
+  },
+  {
+    "symbol": "HasEdit",
+    "url": "object-reference/properties/hasedit"
+  },
+  {
+    "symbol": "Filters",
+    "url": "object-reference/properties/filters"
+  },
+  {
+    "symbol": "File",
+    "url": "object-reference/properties/file"
+  },
+  {
+    "symbol": "Bits",
+    "url": "object-reference/properties/bits"
+  },
+  {
+    "symbol": "CMap",
+    "url": "object-reference/properties/cmap"
+  },
+  {
+    "symbol": "Mask",
+    "url": "object-reference/properties/mask"
+  },
+  {
+    "symbol": "HotSpot",
+    "url": "object-reference/properties/hotspot"
+  },
+  {
+    "symbol": "FileMode",
+    "url": "object-reference/properties/filemode"
+  },
+  {
+    "symbol": "Btns",
+    "url": "object-reference/properties/btns"
+  },
+  {
+    "symbol": "KeepBits",
+    "url": "object-reference/properties/keepbits"
+  },
+  {
+    "symbol": "Coord",
+    "url": "object-reference/properties/coord"
+  },
+  {
+    "symbol": "RealSize",
+    "url": "object-reference/properties/realsize"
+  },
+  {
+    "symbol": "Rows",
+    "url": "object-reference/properties/rows"
+  },
+  {
+    "symbol": "Align",
+    "url": "object-reference/properties/align"
+  },
+  {
+    "symbol": "Fixed",
+    "url": "object-reference/properties/fixed"
+  },
+  {
+    "symbol": "State",
+    "url": "object-reference/properties/state"
+  },
+  {
+    "symbol": "Default",
+    "url": "object-reference/properties/default"
+  },
+  {
+    "symbol": "Cancel",
+    "url": "object-reference/properties/cancel"
+  },
+  {
+    "symbol": "Border",
+    "url": "object-reference/properties/border"
+  },
+  {
+    "symbol": "Justify",
+    "url": "object-reference/properties/justify"
+  },
+  {
+    "symbol": "Active",
+    "url": "object-reference/properties/active"
+  },
+  {
+    "symbol": "Visible",
+    "url": "object-reference/properties/visible"
+  },
+  {
+    "symbol": "LocalAddr",
+    "url": "object-reference/properties/localaddr"
+  },
+  {
+    "symbol": "LocalPort",
+    "url": "object-reference/properties/localport"
+  },
+  {
+    "symbol": "RemoteAddr",
+    "url": "object-reference/properties/remoteaddr"
+  },
+  {
+    "symbol": "RemotePort",
+    "url": "object-reference/properties/remoteport"
+  },
+  {
+    "symbol": "Event",
+    "url": "object-reference/properties/event"
+  },
+  {
+    "symbol": "AllEvents",
+    "url": "object-reference/properties/allevents"
+  },
+  {
+    "symbol": "LocalAddrName",
+    "url": "object-reference/properties/localaddrname"
+  },
+  {
+    "symbol": "LocalPortName",
+    "url": "object-reference/properties/localportname"
+  },
+  {
+    "symbol": "RemoteAddrName",
+    "url": "object-reference/properties/remoteaddrname"
+  },
+  {
+    "symbol": "RemotePortName",
+    "url": "object-reference/properties/remoteportname"
+  },
+  {
+    "symbol": "DragItems",
+    "url": "object-reference/properties/dragitems"
+  },
+  {
+    "symbol": "View",
+    "url": "object-reference/properties/view"
+  },
+  {
+    "symbol": "AutoArrange",
+    "url": "object-reference/properties/autoarrange"
+  },
+  {
+    "symbol": "Header",
+    "url": "object-reference/properties/header"
+  },
+  {
+    "symbol": "Wrap",
+    "url": "object-reference/properties/wrap"
+  },
+  {
+    "symbol": "Depth",
+    "url": "object-reference/properties/depth"
+  },
+  {
+    "symbol": "Indents",
+    "url": "object-reference/properties/indents"
+  },
+  {
+    "symbol": "HasLines",
+    "url": "object-reference/properties/haslines"
+  },
+  {
+    "symbol": "HasButtons",
+    "url": "object-reference/properties/hasbuttons"
+  },
+  {
+    "symbol": "EditLabels",
+    "url": "object-reference/properties/editlabels"
+  },
+  {
+    "symbol": "ImageListObj",
+    "url": "object-reference/properties/imagelistobj"
+  },
+  {
+    "symbol": "ReportInfo",
+    "url": "object-reference/properties/reportinfo"
+  },
+  {
+    "symbol": "ColTitles",
+    "url": "object-reference/properties/coltitles"
+  },
+  {
+    "symbol": "ImageIndex",
+    "url": "object-reference/properties/imageindex"
+  },
+  {
+    "symbol": "SelImageIndex",
+    "url": "object-reference/properties/selimageindex"
+  },
+  {
+    "symbol": "ReportImageList",
+    "url": "object-reference/properties/reportimagelist"
+  },
+  {
+    "symbol": "ReportImageIndex",
+    "url": "object-reference/properties/reportimageindex"
+  },
+  {
+    "symbol": "ReportBCol",
+    "url": "object-reference/properties/reportbcol"
+  },
+  {
+    "symbol": "HeaderImageList",
+    "url": "object-reference/properties/headerimagelist"
+  },
+  {
+    "symbol": "HeaderImageIndex",
+    "url": "object-reference/properties/headerimageindex"
+  },
+  {
+    "symbol": "Wizard",
+    "url": "object-reference/properties/wizard"
+  },
+  {
+    "symbol": "HasApply",
+    "url": "object-reference/properties/hasapply"
+  },
+  {
+    "symbol": "HasHelp",
+    "url": "object-reference/properties/hashelp"
+  },
+  {
+    "symbol": "PageActive",
+    "url": "object-reference/properties/pageactive"
+  },
+  {
+    "symbol": "PageActiveObject",
+    "url": "object-reference/properties/pageactiveobject"
+  },
+  {
+    "symbol": "WaterMarkBitmap",
+    "url": "object-reference/properties/watermarkbitmap"
+  },
+  {
+    "symbol": "HeaderBitmap",
+    "url": "object-reference/properties/headerbitmap"
+  },
+  {
+    "symbol": "Stretch",
+    "url": "object-reference/properties/stretch"
+  },
+  {
+    "symbol": "LastPage",
+    "url": "object-reference/properties/lastpage"
+  },
+  {
+    "symbol": "CaseSensitive",
+    "url": "object-reference/properties/casesensitive"
+  },
+  {
+    "symbol": "EditImage",
+    "url": "object-reference/properties/editimage"
+  },
+  {
+    "symbol": "EditImageIndent",
+    "url": "object-reference/properties/editimageindent"
+  },
+  {
+    "symbol": "PathWordBreak",
+    "url": "object-reference/properties/pathwordbreak"
+  },
+  {
+    "symbol": "FirstDay",
+    "url": "object-reference/properties/firstday"
+  },
+  {
+    "symbol": "MaxSelCount",
+    "url": "object-reference/properties/maxselcount"
+  },
+  {
+    "symbol": "SelDate",
+    "url": "object-reference/properties/seldate"
+  },
+  {
+    "symbol": "DateTime",
+    "url": "object-reference/properties/datetime"
+  },
+  {
+    "symbol": "MinDate",
+    "url": "object-reference/properties/mindate"
+  },
+  {
+    "symbol": "MaxDate",
+    "url": "object-reference/properties/maxdate"
+  },
+  {
+    "symbol": "CalendarCols",
+    "url": "object-reference/properties/calendarcols"
+  },
+  {
+    "symbol": "Today",
+    "url": "object-reference/properties/today"
+  },
+  {
+    "symbol": "HasToday",
+    "url": "object-reference/properties/hastoday"
+  },
+  {
+    "symbol": "CircleToday",
+    "url": "object-reference/properties/circletoday"
+  },
+  {
+    "symbol": "WeekNumbers",
+    "url": "object-reference/properties/weeknumbers"
+  },
+  {
+    "symbol": "MonthDelta",
+    "url": "object-reference/properties/monthdelta"
+  },
+  {
+    "symbol": "HasCheckBox",
+    "url": "object-reference/properties/hascheckbox"
+  },
+  {
+    "symbol": "FieldType",
+    "url": "object-reference/properties/fieldtype"
+  },
+  {
+    "symbol": "CustomFormat",
+    "url": "object-reference/properties/customformat"
+  },
+  {
+    "symbol": "Thumb",
+    "url": "object-reference/properties/thumb"
+  },
+  {
+    "symbol": "Range",
+    "url": "object-reference/properties/range"
+  },
+  {
+    "symbol": "Step",
+    "url": "object-reference/properties/step"
+  },
+  {
+    "symbol": "VScroll",
+    "url": "object-reference/properties/vscroll"
+  },
+  {
+    "symbol": "HScroll",
+    "url": "object-reference/properties/hscroll"
+  },
+  {
+    "symbol": "Limits",
+    "url": "object-reference/properties/limits"
+  },
+  {
+    "symbol": "SelItems",
+    "url": "object-reference/properties/selitems"
+  },
+  {
+    "symbol": "SelText",
+    "url": "object-reference/properties/seltext"
+  },
+  {
+    "symbol": "SelRange",
+    "url": "object-reference/properties/selrange"
+  },
+  {
+    "symbol": "Sizeable",
+    "url": "object-reference/properties/sizeable"
+  },
+  {
+    "symbol": "Moveable",
+    "url": "object-reference/properties/moveable"
+  },
+  {
+    "symbol": "SysMenu",
+    "url": "object-reference/properties/sysmenu"
+  },
+  {
+    "symbol": "MaxButton",
+    "url": "object-reference/properties/maxbutton"
+  },
+  {
+    "symbol": "MinButton",
+    "url": "object-reference/properties/minbutton"
+  },
+  {
+    "symbol": "HelpButton",
+    "url": "object-reference/properties/helpbutton"
+  },
+  {
+    "symbol": "OKButton",
+    "url": "object-reference/properties/okbutton"
+  },
+  {
+    "symbol": "SIPMode",
+    "url": "object-reference/properties/sipmode"
+  },
+  {
+    "symbol": "SIPResize",
+    "url": "object-reference/properties/sipresize"
+  },
+  {
+    "symbol": "Checked",
+    "url": "object-reference/properties/checked"
+  },
+  {
+    "symbol": "Dragable",
+    "url": "object-reference/properties/dragable"
+  },
+  {
+    "symbol": "FontObj",
+    "url": "object-reference/properties/fontobj"
+  },
+  {
+    "symbol": "FontList",
+    "url": "object-reference/properties/fontlist"
+  },
+  {
+    "symbol": "PrintList",
+    "url": "object-reference/properties/printlist"
+  },
+  {
+    "symbol": "Height",
+    "url": "object-reference/properties/height"
+  },
+  {
+    "symbol": "Italic",
+    "url": "object-reference/properties/italic"
+  },
+  {
+    "symbol": "Underline",
+    "url": "object-reference/properties/underline"
+  },
+  {
+    "symbol": "Weight",
+    "url": "object-reference/properties/weight"
+  },
+  {
+    "symbol": "Rotate",
+    "url": "object-reference/properties/rotate"
+  },
+  {
+    "symbol": "CharSet",
+    "url": "object-reference/properties/charset"
+  },
+  {
+    "symbol": "Picture",
+    "url": "object-reference/properties/picture"
+  },
+  {
+    "symbol": "OnTop",
+    "url": "object-reference/properties/ontop"
+  },
+  {
+    "symbol": "BtnPix",
+    "url": "object-reference/properties/btnpix"
+  },
+  {
+    "symbol": "IconObj",
+    "url": "object-reference/properties/iconobj"
+  },
+  {
+    "symbol": "CursorObj",
+    "url": "object-reference/properties/cursorobj"
+  },
+  {
+    "symbol": "AutoConf",
+    "url": "object-reference/properties/autoconf"
+  },
+  {
+    "symbol": "Index",
+    "url": "object-reference/properties/index-property"
+  },
+  {
+    "symbol": "YRange",
+    "url": "object-reference/properties/yrange"
+  },
+  {
+    "symbol": "XRange",
+    "url": "object-reference/properties/xrange"
+  },
+  {
+    "symbol": "EndPos",
+    "url": "object-reference/properties/endpos"
+  },
+  {
+    "symbol": "Data",
+    "url": "object-reference/properties/data"
+  },
+  {
+    "symbol": "Attach",
+    "url": "object-reference/properties/attach"
+  },
+  {
+    "symbol": "Formats",
+    "url": "object-reference/properties/formats"
+  },
+  {
+    "symbol": "CBits",
+    "url": "object-reference/properties/cbits"
+  },
+  {
+    "symbol": "MetafileObj",
+    "url": "object-reference/properties/metafileobj"
+  },
+  {
+    "symbol": "Array",
+    "url": "object-reference/properties/array"
+  },
+  {
+    "symbol": "TextSize",
+    "url": "object-reference/properties/textsize"
+  },
+  {
+    "symbol": "Yield",
+    "url": "object-reference/properties/yield"
+  },
+  {
+    "symbol": "EdgeStyle",
+    "url": "object-reference/properties/edgestyle"
+  },
+  {
+    "symbol": "MDIMenu",
+    "url": "object-reference/properties/mdimenu"
+  },
+  {
+    "symbol": "ClipObj",
+    "url": "object-reference/properties/clipobj"
+  },
+  {
+    "symbol": "ClipMode",
+    "url": "object-reference/properties/clipmode"
+  },
+  {
+    "symbol": "Handle",
+    "url": "object-reference/properties/handle"
+  },
+  {
+    "symbol": "Orientation",
+    "url": "object-reference/properties/orientation"
+  },
+  {
+    "symbol": "Copies",
+    "url": "object-reference/properties/copies"
+  },
+  {
+    "symbol": "PrintRange",
+    "url": "object-reference/properties/printrange"
+  },
+  {
+    "symbol": "Collate",
+    "url": "object-reference/properties/collate"
+  },
+  {
+    "symbol": "PaperSize",
+    "url": "object-reference/properties/papersize"
+  },
+  {
+    "symbol": "PaperSizes",
+    "url": "object-reference/properties/papersizes"
+  },
+  {
+    "symbol": "PaperSource",
+    "url": "object-reference/properties/papersource"
+  },
+  {
+    "symbol": "PaperSources",
+    "url": "object-reference/properties/papersources"
+  },
+  {
+    "symbol": "ColorMode",
+    "url": "object-reference/properties/colormode"
+  },
+  {
+    "symbol": "Resolution",
+    "url": "object-reference/properties/resolution"
+  },
+  {
+    "symbol": "Resolutions",
+    "url": "object-reference/properties/resolutions"
+  },
+  {
+    "symbol": "Duplex",
+    "url": "object-reference/properties/duplex"
+  },
+  {
+    "symbol": "MDIActive",
+    "url": "object-reference/properties/mdiactive"
+  },
+  {
+    "symbol": "MDIActiveObject",
+    "url": "object-reference/properties/mdiactiveobject"
+  },
+  {
+    "symbol": "HintObj",
+    "url": "object-reference/properties/hintobj"
+  },
+  {
+    "symbol": "TipObj",
+    "url": "object-reference/properties/tipobj"
+  },
+  {
+    "symbol": "TabObj",
+    "url": "object-reference/properties/tabobj"
+  },
+  {
+    "symbol": "MaxLength",
+    "url": "object-reference/properties/maxlength"
+  },
+  {
+    "symbol": "Decimals",
+    "url": "object-reference/properties/decimals"
+  },
+  {
+    "symbol": "Password",
+    "url": "object-reference/properties/password"
+  },
+  {
+    "symbol": "ValidIfEmpty",
+    "url": "object-reference/properties/validifempty"
+  },
+  {
+    "symbol": "ReadOnly",
+    "url": "object-reference/properties/readonly"
+  },
+  {
+    "symbol": "FormatString",
+    "url": "object-reference/properties/formatstring"
+  },
+  {
+    "symbol": "Changed",
+    "url": "object-reference/properties/changed"
+  },
+  {
+    "symbol": "RTFText",
+    "url": "object-reference/properties/rtftext"
+  },
+  {
+    "symbol": "RowTitles",
+    "url": "object-reference/properties/rowtitles"
+  },
+  {
+    "symbol": "CurCell",
+    "url": "object-reference/properties/curcell"
+  },
+  {
+    "symbol": "TitleWidth",
+    "url": "object-reference/properties/titlewidth"
+  },
+  {
+    "symbol": "CellHeights",
+    "url": "object-reference/properties/cellheights"
+  },
+  {
+    "symbol": "CellWidths",
+    "url": "object-reference/properties/cellwidths"
+  },
+  {
+    "symbol": "TitleHeight",
+    "url": "object-reference/properties/titleheight"
+  },
+  {
+    "symbol": "CellFonts",
+    "url": "object-reference/properties/cellfonts"
+  },
+  {
+    "symbol": "Input",
+    "url": "object-reference/properties/input"
+  },
+  {
+    "symbol": "Value",
+    "url": "object-reference/properties/value"
+  },
+  {
+    "symbol": "CellTypes",
+    "url": "object-reference/properties/celltypes"
+  },
+  {
+    "symbol": "AutoExpand",
+    "url": "object-reference/properties/autoexpand"
+  },
+  {
+    "symbol": "CellSelect",
+    "url": "object-reference/properties/cellselect"
+  },
+  {
+    "symbol": "ResizeRows",
+    "url": "object-reference/properties/resizerows"
+  },
+  {
+    "symbol": "ResizeCols",
+    "url": "object-reference/properties/resizecols"
+  },
+  {
+    "symbol": "ResizeRowTitles",
+    "url": "object-reference/properties/resizerowtitles"
+  },
+  {
+    "symbol": "ResizeColTitles",
+    "url": "object-reference/properties/resizecoltitles"
+  },
+  {
+    "symbol": "ClipCells",
+    "url": "object-reference/properties/clipcells"
+  },
+  {
+    "symbol": "InputModeKey",
+    "url": "object-reference/properties/inputmodekey"
+  },
+  {
+    "symbol": "InputMode",
+    "url": "object-reference/properties/inputmode"
+  },
+  {
+    "symbol": "GridFCol",
+    "url": "object-reference/properties/gridfcol"
+  },
+  {
+    "symbol": "GridBCol",
+    "url": "object-reference/properties/gridbcol"
+  },
+  {
+    "symbol": "ShowInput",
+    "url": "object-reference/properties/showinput"
+  },
+  {
+    "symbol": "CellSet",
+    "url": "object-reference/properties/cellset"
+  },
+  {
+    "symbol": "RowTitleFCol",
+    "url": "object-reference/properties/rowtitlefcol"
+  },
+  {
+    "symbol": "ColTitleFCol",
+    "url": "object-reference/properties/coltitlefcol"
+  },
+  {
+    "symbol": "RowTitleDepth",
+    "url": "object-reference/properties/rowtitledepth"
+  },
+  {
+    "symbol": "ColTitleDepth",
+    "url": "object-reference/properties/coltitledepth"
+  },
+  {
+    "symbol": "RowTitleAlign",
+    "url": "object-reference/properties/rowtitlealign"
+  },
+  {
+    "symbol": "ColTitleAlign",
+    "url": "object-reference/properties/coltitlealign"
+  },
+  {
+    "symbol": "OverflowChar",
+    "url": "object-reference/properties/overflowchar"
+  },
+  {
+    "symbol": "AlignChar",
+    "url": "object-reference/properties/alignchar"
+  },
+  {
+    "symbol": "GridLineFCol",
+    "url": "object-reference/properties/gridlinefcol"
+  },
+  {
+    "symbol": "GridLineWidth",
+    "url": "object-reference/properties/gridlinewidth"
+  },
+  {
+    "symbol": "RowLineTypes",
+    "url": "object-reference/properties/rowlinetypes"
+  },
+  {
+    "symbol": "ColLineTypes",
+    "url": "object-reference/properties/collinetypes"
+  },
+  {
+    "symbol": "EnterReadOnlyCells",
+    "url": "object-reference/properties/enterreadonlycells"
+  },
+  {
+    "symbol": "RowTitle3D",
+    "url": "object-reference/properties/rowtitle3d"
+  },
+  {
+    "symbol": "ColTitle3D",
+    "url": "object-reference/properties/coltitle3d"
+  },
+  {
+    "symbol": "RowTitleBCol",
+    "url": "object-reference/properties/rowtitlebcol"
+  },
+  {
+    "symbol": "ColTitleBCol",
+    "url": "object-reference/properties/coltitlebcol"
+  },
+  {
+    "symbol": "RowTreeDepth",
+    "url": "object-reference/properties/rowtreedepth"
+  },
+  {
+    "symbol": "RowTreeStyle",
+    "url": "object-reference/properties/rowtreestyle"
+  },
+  {
+    "symbol": "RowTreeImages",
+    "url": "object-reference/properties/rowtreeimages"
+  },
+  {
+    "symbol": "ColSortImages",
+    "url": "object-reference/properties/colsortimages"
+  },
+  {
+    "symbol": "SelectionColor",
+    "url": "object-reference/properties/selectioncolor"
+  },
+  {
+    "symbol": "SelectionColorAlpha",
+    "url": "object-reference/properties/selectioncoloralpha"
+  },
+  {
+    "symbol": "SelectionBorderWidth",
+    "url": "object-reference/properties/selectionborderwidth"
+  },
+  {
+    "symbol": "HighlightHeaders",
+    "url": "object-reference/properties/highlightheaders"
+  },
+  {
+    "symbol": "Translate",
+    "url": "object-reference/properties/translate"
+  },
+  {
+    "symbol": "Accelerator",
+    "url": "object-reference/properties/accelerator"
+  },
+  {
+    "symbol": "CurObj",
+    "url": "object-reference/properties/curobj"
+  },
+  {
+    "symbol": "CurWin",
+    "url": "object-reference/properties/curwin"
+  },
+  {
+    "symbol": "CurPos",
+    "url": "object-reference/properties/curpos"
+  },
+  {
+    "symbol": "CurSpace",
+    "url": "object-reference/properties/curspace"
+  },
+  {
+    "symbol": "Log",
+    "url": "object-reference/properties/log"
+  },
+  {
+    "symbol": "Popup",
+    "url": "object-reference/properties/popup"
+  },
+  {
+    "symbol": "APLVersion",
+    "url": "object-reference/properties/aplversion"
+  },
+  {
+    "symbol": "EvaluationDays",
+    "url": "object-reference/properties/evaluationdays"
+  },
+  {
+    "symbol": "TickAlign",
+    "url": "object-reference/properties/tickalign"
+  },
+  {
+    "symbol": "TickSpacing",
+    "url": "object-reference/properties/tickspacing"
+  },
+  {
+    "symbol": "HasTicks",
+    "url": "object-reference/properties/hasticks"
+  },
+  {
+    "symbol": "ShowThumb",
+    "url": "object-reference/properties/showthumb"
+  },
+  {
+    "symbol": "TrackRect",
+    "url": "object-reference/properties/trackrect"
+  },
+  {
+    "symbol": "ThumbRect",
+    "url": "object-reference/properties/thumbrect"
+  },
+  {
+    "symbol": "CharFormat",
+    "url": "object-reference/properties/charformat"
+  },
+  {
+    "symbol": "WordFormat",
+    "url": "object-reference/properties/wordformat"
+  },
+  {
+    "symbol": "ParaFormat",
+    "url": "object-reference/properties/paraformat"
+  },
+  {
+    "symbol": "PageWidth",
+    "url": "object-reference/properties/pagewidth"
+  },
+  {
+    "symbol": "ImageCount",
+    "url": "object-reference/properties/imagecount"
+  },
+  {
+    "symbol": "Masked",
+    "url": "object-reference/properties/masked"
+  },
+  {
+    "symbol": "MapCols",
+    "url": "object-reference/properties/mapcols"
+  },
+  {
+    "symbol": "CMap",
+    "url": "object-reference/properties/cmap"
+  },
+  {
+    "symbol": "AcceptFiles",
+    "url": "object-reference/properties/acceptfiles"
+  },
+  {
+    "symbol": "WantsReturn",
+    "url": "object-reference/properties/wantsreturn"
+  },
+  {
+    "symbol": "MultiColumn",
+    "url": "object-reference/properties/multicolumn"
+  },
+  {
+    "symbol": "ColumnWidth",
+    "url": "object-reference/properties/columnwidth"
+  },
+  {
+    "symbol": "SocketType",
+    "url": "object-reference/properties/sockettype"
+  },
+  {
+    "symbol": "SocketNumber",
+    "url": "object-reference/properties/socketnumber"
+  },
+  {
+    "symbol": "CurrentState",
+    "url": "object-reference/properties/currentstate"
+  },
+  {
+    "symbol": "TargetState",
+    "url": "object-reference/properties/targetstate"
+  },
+  {
+    "symbol": "ExportedFns",
+    "url": "object-reference/properties/exportedfns"
+  },
+  {
+    "symbol": "ExportedVars",
+    "url": "object-reference/properties/exportedvars"
+  },
+  {
+    "symbol": "ClassID",
+    "url": "object-reference/properties/classid"
+  },
+  {
+    "symbol": "Container",
+    "url": "object-reference/properties/container"
+  },
+  {
+    "symbol": "KeepOnClose",
+    "url": "object-reference/properties/keeponclose"
+  },
+  {
+    "symbol": "OLEControls",
+    "url": "object-reference/properties/olecontrols"
+  },
+  {
+    "symbol": "OLEServers",
+    "url": "object-reference/properties/oleservers"
+  },
+  {
+    "symbol": "TypeList",
+    "url": "object-reference/properties/typelist"
+  },
+  {
+    "symbol": "HelpFile",
+    "url": "object-reference/properties/helpfile"
+  },
+  {
+    "symbol": "ToolboxBitmap",
+    "url": "object-reference/properties/toolboxbitmap"
+  },
+  {
+    "symbol": "LicenseKey",
+    "url": "object-reference/properties/licensekey"
+  },
+  {
+    "symbol": "ObjectName",
+    "url": "object-reference/properties/objectname"
+  },
+  {
+    "symbol": "UserID",
+    "url": "object-reference/properties/userid"
+  },
+  {
+    "symbol": "TypeLibID",
+    "url": "object-reference/properties/typelibid"
+  },
+  {
+    "symbol": "TypeLibFile",
+    "url": "object-reference/properties/typelibfile"
+  },
+  {
+    "symbol": "ServerVersion",
+    "url": "object-reference/properties/serverversion"
+  },
+  {
+    "symbol": "LastError",
+    "url": "object-reference/properties/lasterror"
+  },
+  {
+    "symbol": "RunMode",
+    "url": "object-reference/properties/runmode"
+  },
+  {
+    "symbol": "ShowSession",
+    "url": "object-reference/properties/showsession"
+  },
+  {
+    "symbol": "Locale",
+    "url": "object-reference/properties/locale"
+  },
+  {
+    "symbol": "DrawMode",
+    "url": "object-reference/properties/drawmode"
+  },
+  {
+    "symbol": "RadiusMode",
+    "url": "object-reference/properties/radiusmode"
+  },
+  {
+    "symbol": "AutoBrowse",
+    "url": "object-reference/properties/autobrowse"
+  },
+  {
+    "symbol": "QueueEvents",
+    "url": "object-reference/properties/queueevents"
+  },
+  {
+    "symbol": "MultiLine",
+    "url": "object-reference/properties/multiline"
+  },
+  {
+    "symbol": "TabSize",
+    "url": "object-reference/properties/tabsize"
+  },
+  {
+    "symbol": "TabJustify",
+    "url": "object-reference/properties/tabjustify"
+  },
+  {
+    "symbol": "MultiSelect",
+    "url": "object-reference/properties/multiselect"
+  },
+  {
+    "symbol": "TabFocus",
+    "url": "object-reference/properties/tabfocus"
+  },
+  {
+    "symbol": "HotTrack",
+    "url": "object-reference/properties/hottrack"
+  },
+  {
+    "symbol": "ScrollOpposite",
+    "url": "object-reference/properties/scrollopposite"
+  },
+  {
+    "symbol": "FlatSeparators",
+    "url": "object-reference/properties/flatseparators"
+  },
+  {
+    "symbol": "Transparent",
+    "url": "object-reference/properties/transparent"
+  },
+  {
+    "symbol": "BandBorders",
+    "url": "object-reference/properties/bandborders"
+  },
+  {
+    "symbol": "ChildEdge",
+    "url": "object-reference/properties/childedge"
+  },
+  {
+    "symbol": "DblClickToggle",
+    "url": "object-reference/properties/dblclicktoggle"
+  },
+  {
+    "symbol": "FixedOrder",
+    "url": "object-reference/properties/fixedorder"
+  },
+  {
+    "symbol": "VariableHeight",
+    "url": "object-reference/properties/variableheight"
+  },
+  {
+    "symbol": "Divider",
+    "url": "object-reference/properties/divider"
+  },
+  {
+    "symbol": "NewLine",
+    "url": "object-reference/properties/newline"
+  },
+  {
+    "symbol": "GripperMode",
+    "url": "object-reference/properties/grippermode"
+  },
+  {
+    "symbol": "ShowCaptions",
+    "url": "object-reference/properties/showcaptions"
+  },
+  {
+    "symbol": "ShowDropDown",
+    "url": "object-reference/properties/showdropdown"
+  },
+  {
+    "symbol": "CheckBoxes",
+    "url": "object-reference/properties/checkboxes"
+  },
+  {
+    "symbol": "FullRowSelect",
+    "url": "object-reference/properties/fullrowselect"
+  },
+  {
+    "symbol": "GridLines",
+    "url": "object-reference/properties/gridlines"
+  },
+  {
+    "symbol": "ProgressStyle",
+    "url": "object-reference/properties/progressstyle"
+  },
+  {
+    "symbol": "SingleClickExpand",
+    "url": "object-reference/properties/singleclickexpand"
+  },
+  {
+    "symbol": "Dockable",
+    "url": "object-reference/properties/dockable"
+  },
+  {
+    "symbol": "Docked",
+    "url": "object-reference/properties/docked"
+  },
+  {
+    "symbol": "DockShowCaption",
+    "url": "object-reference/properties/dockshowcaption"
+  },
+  {
+    "symbol": "DockChildren",
+    "url": "object-reference/properties/dockchildren"
+  },
+  {
+    "symbol": "UndocksToRoot",
+    "url": "object-reference/properties/undockstoroot"
+  },
+  {
+    "symbol": "AsSubForm",
+    "url": "object-reference/properties/assubform"
+  },
+  {
+    "symbol": "AsCoolBand",
+    "url": "object-reference/properties/ascoolband"
+  },
+  {
+    "symbol": "MaskCol",
+    "url": "object-reference/properties/maskcol"
+  },
+  {
+    "symbol": "AlphaBlend",
+    "url": "object-reference/properties/alphablend"
+  },
+  {
+    "symbol": "AutoPlay",
+    "url": "object-reference/properties/autoplay"
+  },
+  {
+    "symbol": "Redraw",
+    "url": "object-reference/properties/redraw"
+  },
+  {
+    "symbol": "HotKey",
+    "url": "object-reference/properties/hotkey"
+  },
+  {
+    "symbol": "Rules",
+    "url": "object-reference/properties/rules"
+  },
+  {
+    "symbol": "DefaultModifier",
+    "url": "object-reference/properties/defaultmodifier"
+  },
+  {
+    "symbol": "TimeUnits",
+    "url": "object-reference/properties/timeunits"
+  },
+  {
+    "symbol": "Length",
+    "url": "object-reference/properties/length"
+  },
+  {
+    "symbol": "Repeat",
+    "url": "object-reference/properties/repeat"
+  },
+  {
+    "symbol": "StartPos",
+    "url": "object-reference/properties/startpos"
+  },
+  {
+    "symbol": "AutoSizeWindow",
+    "url": "object-reference/properties/autosizewindow"
+  },
+  {
+    "symbol": "AutoSizeMovie",
+    "url": "object-reference/properties/autosizemovie"
+  },
+  {
+    "symbol": "MCIErrorDLG",
+    "url": "object-reference/properties/mcierrordlg"
+  },
+  {
+    "symbol": "HaveMenu",
+    "url": "object-reference/properties/havemenu"
+  },
+  {
+    "symbol": "HaveOpen",
+    "url": "object-reference/properties/haveopen"
+  },
+  {
+    "symbol": "PlayBar",
+    "url": "object-reference/properties/playbar"
+  },
+  {
+    "symbol": "ShowMode",
+    "url": "object-reference/properties/showmode"
+  },
+  {
+    "symbol": "ShowName",
+    "url": "object-reference/properties/showname"
+  },
+  {
+    "symbol": "ShowPos",
+    "url": "object-reference/properties/showpos"
+  },
+  {
+    "symbol": "Zoom",
+    "url": "object-reference/properties/zoom"
+  },
+  {
+    "symbol": "Volume",
+    "url": "object-reference/properties/volume"
+  },
+  {
+    "symbol": "CanConfig",
+    "url": "object-reference/properties/canconfig"
+  },
+  {
+    "symbol": "CanEject",
+    "url": "object-reference/properties/caneject"
+  },
+  {
+    "symbol": "CanPlay",
+    "url": "object-reference/properties/canplay"
+  },
+  {
+    "symbol": "Timers",
+    "url": "object-reference/properties/timers"
+  },
+  {
+    "symbol": "DebugBuild",
+    "url": "object-reference/properties/debugbuild"
+  },
+  {
+    "symbol": "InstanceMode",
+    "url": "object-reference/properties/instancemode"
+  },
+  {
+    "symbol": "SortItems",
+    "url": "object-reference/properties/sortitems"
+  },
+  {
+    "symbol": "InputProperties",
+    "url": "object-reference/properties/inputproperties"
+  },
+  {
+    "symbol": "TabIndex",
+    "url": "object-reference/properties/tabindex"
+  },
+  {
+    "symbol": "AlwaysShowSelection",
+    "url": "object-reference/properties/alwaysshowselection"
+  },
+  {
+    "symbol": "AlwaysShowBorder",
+    "url": "object-reference/properties/alwaysshowborder"
+  },
+  {
+    "symbol": "ItemGroups",
+    "url": "object-reference/properties/itemgroups"
+  },
+  {
+    "symbol": "ItemGroupMetrics",
+    "url": "object-reference/properties/itemgroupmetrics"
+  },
+  {
+    "symbol": "StatusWindow",
+    "url": "object-reference/properties/statuswindow"
+  },
+  {
+    "symbol": "Editor",
+    "url": "object-reference/properties/editor"
+  },
+  {
+    "symbol": "ScriptCompiler",
+    "url": "object-reference/properties/scriptcompiler"
+  },
+  {
+    "symbol": "VScrollGroup",
+    "url": "object-reference/properties/vscrollgroup"
+  },
+  {
+    "symbol": "HScrollGroup",
+    "url": "object-reference/properties/hscrollgroup"
+  },
+  {
+    "symbol": "Encoding",
+    "url": "object-reference/properties/encoding"
+  },
+  {
+    "symbol": "PageSize",
+    "url": "object-reference/properties/pagesize"
+  },
+  {
+    "symbol": "RowHiddenDepth",
+    "url": "object-reference/properties/rowhiddendepth"
+  },
+  {
+    "symbol": "Elevated",
+    "url": "object-reference/properties/elevated"
+  },
+  {
+    "symbol": "Note",
+    "url": "object-reference/properties/note"
+  },
+  {
+    "symbol": "Cue",
+    "url": "object-reference/properties/cue"
+  },
+  {
+    "symbol": "CornerTitleBCol",
+    "url": "object-reference/properties/cornertitlebcol"
+  },
+  {
+    "symbol": "ShowCueWhenFocused",
+    "url": "object-reference/properties/showcuewhenfocused"
+  },
+  {
+    "symbol": "ButtonsAcceptFocus",
+    "url": "object-reference/properties/buttonsacceptfocus"
+  },
+  {
+    "symbol": "LateBind",
+    "url": "object-reference/properties/latebind"
+  },
+  {
+    "symbol": "HasClearButton",
+    "url": "object-reference/properties/hasclearbutton"
+  },
+  {
+    "symbol": "AsChild",
+    "url": "object-reference/properties/aschild"
+  },
+  {
+    "symbol": "InterceptedURLs",
+    "url": "object-reference/properties/interceptedurls"
+  },
+  {
+    "symbol": "CEFVersion",
+    "url": "object-reference/properties/cefversion"
+  },
+  {
+    "symbol": "MethodList",
+    "url": "object-reference/properties/methodlist"
+  },
+  {
+    "symbol": "ChildList",
+    "url": "object-reference/properties/childlist"
+  },
+  {
+    "symbol": "EventList",
+    "url": "object-reference/properties/eventlist"
+  },
+  {
+    "symbol": "PropList",
+    "url": "object-reference/properties/proplist"
+  }
+]


### PR DESCRIPTION
## Summary
- Replace C preprocessor macro parsing (`help_urls.h`) with a simple JSON file (`symbol-urls.json`) for symbol-to-documentation URL mapping
- Remove brittle macro expansion code which had a map-iteration-order bug causing garbled URLs for some symbols
- The resulting database is a strict superset of the old one: 0 symbols lost, 10 gained from the macro fix

## Test plan
- [ ] Run `go build ./cmd/bundle-docs` to verify it compiles
- [ ] Run bundle-docs with the new `symbol-urls.json` and verify the output database
- [ ] Spot-check F1 help lookups in gritt for common symbols (`⍳`, `⍴`, `⍉`, etc.)